### PR TITLE
フォント、ブランドカラーなどのグローバル SCSS 変数の設定

### DIFF
--- a/app/assets/styles/_base.scss
+++ b/app/assets/styles/_base.scss
@@ -11,6 +11,10 @@ html {
 }
 
 body {
-  // @include body;
-  // background-color: $black;
+  @include body;
+  background-color: $black;
+}
+
+a {
+  color: $primary;
 }

--- a/app/assets/styles/_reset.scss
+++ b/app/assets/styles/_reset.scss
@@ -291,6 +291,5 @@
   }
 
   a {
-    // color: $black;
     text-decoration: none;
   }

--- a/app/assets/styles/_variables.scss
+++ b/app/assets/styles/_variables.scss
@@ -1,0 +1,115 @@
+// for only sp view with iPhone XS Max's width
+$maxViewWidth: 414px;
+//
+// Fonts
+//
+@font-face {
+  font-family: "-apple-system-subset";
+  src: local(-apple-system);
+  unicode-range: U+0000-05C7;
+}
+$font-family: -apple-system-subset, Hiragino Sans, BlinkMacSystemFont, Roboto, '游ゴシック体', YuGothic, 'Yu Gothic Medium', sans-serif;
+//
+// Colors
+//
+// Mono
+$black: #1b1b1b; // Material Glay 800 Dark
+$gray: #616161; // Material Glay 700
+$lightGray: #8e8e8e; // Material Glay 700 Light
+$white: #ffffff;
+
+// Bland
+$primary: #007c91; // Material Cyan 600 Dark
+$secondary: #d81b60; // Material Pink 600
+
+// Emphasis
+$danger: #ba000d; // Material Red 500 Dark
+$warning: #fdd835; // Material Yellow 600
+
+// Boundary
+$boundaryBlack: rgba(46, 56, 54, 0.13);
+//
+// Shadows
+//
+$shadowHigh: rgba(46, 56, 54, 0.2) 0px 3px 3px -2px, rgba(46, 56, 54, 0.14) 0px 3px 4px 0px, rgba(46, 56, 54, 0.12) 0px 1px 8px 0px;
+$shadowMiddle: rgba(46, 56, 54, 0.2) 0px 3px 1px -2px,rgba(46, 56, 54, 0.14) 0px 2px 2px 0px, rgba(46, 56, 54, 0.12) 0px 1px 5px 0px;
+$shadowLow: rgba(46, 56, 54, 0.2) 0px 2px 1px -1px, rgba(46, 56, 54, 0.14) 0px 1px 1px 0px, rgba(46, 56, 54, 0.12) 0px 1px 3px 0px;
+//
+// Text styles
+//
+@mixin caption {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 155%;
+  letter-spacing: 0.002em;
+  color: $black;
+}
+
+@mixin body {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 14px;
+  line-height: 150%;
+  letter-spacing: 0.008em;
+  color: $black;
+}
+
+@mixin strong {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 149%;
+  color: $black;
+}
+
+@mixin input {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 145%;
+  color: $black;
+}
+
+@mixin subhead {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 158%;
+  color: $black;
+}
+
+@mixin title-3 {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 140%;
+  letter-spacing: -0.01em;
+  color: $black;
+}
+
+@mixin title-2 {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 148%;
+  letter-spacing: -0.02em;
+  color: $black;
+}
+
+@mixin title-1 {
+  font-family: $font-family;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 23px;
+  line-height: 140%;
+  letter-spacing: -0.01em;
+  color: $black;
+}

--- a/app/assets/styles/index.scss
+++ b/app/assets/styles/index.scss
@@ -1,2 +1,3 @@
+@import './variables';
 @import './reset';
 @import './base';

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,7 +87,11 @@ export default {
   /*
    ** Nuxt.js modules
    */
-  modules: ['@nuxtjs/pwa'],
+  modules: ['@nuxtjs/pwa', '@nuxtjs/style-resources'],
+  //
+  styleResources: {
+    scss: ['~/assets/styles/_variables.scss']
+  },
   //
   // Web App manifest
   //


### PR DESCRIPTION
## 📝 関連 issue
resolves #18 

## 🔨 変更内容
+ nuxt.config モジュールによる SCSS 変数のバンドル設定を追加
+ グローバル SCSS 変数を定義した styles/_variablse.scss を追加
+ body タグ および a タグについてのグローバルスタイルを追加

## 👀 確認手順
+ [ ] グロバール SCSS がバンドルされていることを確認
