### PR TITLE
Firebase auth().currentUser をリアクティブなデータとして注入を行うプラグインの作成

### DIFF
--- a/app/plugins/firebase/auth.js
+++ b/app/plugins/firebase/auth.js
@@ -1,0 +1,17 @@
+import Vue from 'vue'
+import firebase from 'firebase/app'
+import 'firebase/auth'
+
+export default (context, inject) =>
+  new Promise((resolve) => {
+    const observable = Vue.observable({
+      currentUser: firebase.auth().currentUser
+    })
+
+    inject('currentUser', observable.currentUser)
+
+    firebase.auth().onAuthStateChanged(() => {
+      observable.currentUser = firebase.auth().currentUser
+      resolve()
+    })
+  })

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,7 +76,11 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: ['~/plugins/firebase/init.js', '~/plugins/firebase/analytics.js'],
+  plugins: [
+    '~/plugins/firebase/init.js',
+    '~/plugins/firebase/analytics.js',
+    '~/plugins/firebase/auth.js'
+  ],
   /*
    ** Nuxt.js dev-modules
    */


### PR DESCRIPTION
## 📝 関連 issue
resolves #47 

## 🔨 変更内容
+ plugins/firebase/auth の作成
  + Vue.observable を利用した `firebase.auth().onAuthStateChanged()` による認証情報の監視ロジックを追加
  + inject 関数による `firebase.auth().currentUser` の注入ロジックを追加
+ nuxt.config  上記 plugins を登録

## 👀 確認手順
+ [ ] 実装コードを確認
+ [ ] contect および Vue インスタンス から `currentUser` が参照できることを確認
