### PR TITLE
Firebase SDK の各 API を inject 関数によって nuxt に注入する plugins の作成

### DIFF
--- a/app/plugins/firebase/inject.js
+++ b/app/plugins/firebase/inject.js
@@ -1,0 +1,10 @@
+import firebase from 'firebase/app'
+import 'firebase/auth'
+import 'firebase/firestore'
+import 'firebase/functions'
+
+export default (context, inject) => {
+  inject('firestore', firebase.firestore)
+  inject('functions', firebase.app().functions('asia-northeast1'))
+  inject('auth', firebase.auth())
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,7 +80,8 @@ export default {
   plugins: [
     '~/plugins/firebase/init.js',
     '~/plugins/firebase/analytics.js',
-    '~/plugins/firebase/auth.js'
+    '~/plugins/firebase/auth.js',
+    '~/plugins/firebase/inject.js'
   ],
   /*
    ** Nuxt.js dev-modules


### PR DESCRIPTION
## 📝 関連 issue
resolves #52 

## 🔨 変更内容
+ plugins/firebase/inject の作成
  + `firebase.firestore`, `firebase.auth()`, `firebase.app().functions('asia-northeast1')` についてそれぞれ inject を作成
+ nuxt.config 上記 plugins の登録

## 👀 確認手順
+ [ ] nuxt の API から inject された Firebase SDK の API を確認
