### PR TITLE
新規登録ページに Firebase Authentication のロジックを追加

### DIFF
--- a/app/components/signup/FormSignUp.vue
+++ b/app/components/signup/FormSignUp.vue
@@ -27,7 +27,11 @@
     <p class="caption">
       6文字以上の半角英数字または記号
     </p>
-    <BaseButton label="登録する" :disabled="!isFormValid" />
+    <BaseButton
+      label="登録する"
+      :disabled="!isFormValid"
+      @onClick="createAccount()"
+    />
   </form>
 </template>
 
@@ -69,6 +73,45 @@ export default {
     isFormValid() {
       const { isNameValid, isEmailValid, isPassValid } = this
       return isNameValid && isEmailValid && isPassValid
+    }
+  },
+
+  methods: {
+    handleError(error) {
+      alert(
+        'アカウント作成に失敗しました。しばらくしてから再度お試しいただくか、お問い合わせください。'
+      )
+      if (error) throw new Error(error)
+    },
+
+    async createAccount() {
+      if (!this.isFormValid) return
+
+      const { email, password } = this
+
+      this.$store.commit('setIsLoading', true)
+
+      await this.$auth
+        .createUserWithEmailAndPassword(email, password)
+        .then(() => this.sendEmailVerification())
+        .catch((error) => {
+          switch (error.code) {
+            case 'auth/email-already-in-use':
+              alert(`${email}はすでに使用されています。`)
+              break
+            case 'auth/invalid-email':
+              alert(`${email}は無効なメールアドレスです。`)
+              break
+            default:
+              this.handleError()
+              break
+          }
+          this.$store.commit('setIsLoading', false)
+        })
+    },
+
+    async sendEmailVerification() {
+      // will be added logic
     }
   }
 }

--- a/app/components/signup/FormSignUp.vue
+++ b/app/components/signup/FormSignUp.vue
@@ -81,7 +81,7 @@ export default {
       alert(
         'アカウント作成に失敗しました。しばらくしてから再度お試しいただくか、お問い合わせください。'
       )
-      if (error) throw new Error(error)
+      this.$nuxt.error(error)
     },
 
     async createAccount() {
@@ -103,7 +103,7 @@ export default {
               alert(`${email}は無効なメールアドレスです。`)
               break
             default:
-              this.handleError()
+              this.handleError(error)
               break
           }
           this.$store.commit('setIsLoading', false)
@@ -111,7 +111,25 @@ export default {
     },
 
     async sendEmailVerification() {
-      // will be added logic
+      const user = this.$auth.currentUser
+      if (!user) return
+
+      // To be included in the body of the email
+      await user
+        .updateProfile({ displayName: this.displayName })
+        .catch((error) => this.handleError(error))
+
+      // Send email & create firestore user document
+      Promise.all([
+        user.sendEmailVerification()
+        // will be added firestore query
+      ])
+        .then(async () => {
+          // Sign out to wait for email confirmation
+          await this.$auth.signOut()
+        })
+        .catch((error) => this.handleError(error))
+        .finally(() => this.$store.commit('setIsLoading', false))
     }
   }
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,6 +8,12 @@
     </h2>
 
     <footer class="footer-links">
+      <BaseButton
+        label="はじめる"
+        :disabled="false"
+        class="signup"
+        @onClick="$router.push('/signup/')"
+      />
       <p class="support">
         <nuxt-link to="/terms/">利用規約</nuxt-link>
         <span>/</span>
@@ -18,7 +24,13 @@
 </template>
 
 <script>
+import BaseButton from '~/components/form/BaseButton'
+
 export default {
+  components: {
+    BaseButton
+  },
+
   head() {
     return {
       titleTemplate: '',
@@ -58,6 +70,10 @@ export default {
   padding: 0 16px;
   width: 100%;
   max-width: $maxViewWidth;
+
+  > .signup {
+    margin-bottom: 16px;
+  }
 
   > .support {
     @include caption;


### PR DESCRIPTION
## 📝 関連 issue
related to #32 

## 🔨 変更内容
+ components/FormSignUp: Firebase Authentication のロジックを追加
  + `createUserWithEmailAndPassword()` メールアドレスとパスワードによるユーザーの作成
  + `sendEmailVerification()` 確認メールの送信
  + `updateProfile()` メール送信に際して、メール本文に記載されるディスプレイネームを更新
+ pages/index.vue: /signup への導線となるボタンを追加

## 👀 確認手順
+ [ ] ホームから新規登録ページへの導線を確認
+ [ ] ユーザー登録により、Firebase Authentication ユーザーの作成ならびにメールの受信を確認
