### PR TITLE
Firestore ユーザーモデル作成のクエリの追加ならびにルールの更新

### DIFF
--- a/app/components/signup/FormSignUp.vue
+++ b/app/components/signup/FormSignUp.vue
@@ -38,6 +38,7 @@
 <script>
 import BaseInputText from '~/components/form/BaseInputText'
 import BaseButton from '~/components/form/BaseButton'
+import { createUser } from '~/repositories/firestore/users'
 
 export default {
   components: {
@@ -112,21 +113,27 @@ export default {
 
     async sendEmailVerification() {
       const user = this.$auth.currentUser
-      if (!user) return
+      if (!user) {
+        this.handleError()
+        this.$store.commit('setIsLoading', false)
+        return
+      }
+
+      const displayName = this.displayName
 
       // To be included in the body of the email
       await user
-        .updateProfile({ displayName: this.displayName })
+        .updateProfile({ displayName })
         .catch((error) => this.handleError(error))
 
       // Send email & create firestore user document
       Promise.all([
-        user.sendEmailVerification()
-        // will be added firestore query
+        user.sendEmailVerification(),
+        createUser({ uid: user.uid, displayName })
       ])
         .then(async () => {
-          // Sign out to wait for email confirmation
-          await this.$auth.signOut()
+          this.$emit('onCompleteSignUp', this.email)
+          await this.$auth.signOut() // Sign out to wait for email confirmation
         })
         .catch((error) => this.handleError(error))
         .finally(() => this.$store.commit('setIsLoading', false))

--- a/app/repositories/firestore/config.js
+++ b/app/repositories/firestore/config.js
@@ -1,0 +1,10 @@
+import firebase from '~/plugins/firebase/init'
+import 'firebase/firestore'
+
+const db = firebase.firestore()
+const fieldVal = firebase.firestore.FieldValue
+export const timestamp = fieldVal.serverTimestamp()
+
+// reference of collection
+const ref = (ref) => db.collection(ref)
+export const usersRef = ref('users')

--- a/app/repositories/firestore/users/index.js
+++ b/app/repositories/firestore/users/index.js
@@ -1,0 +1,17 @@
+import { usersRef, timestamp } from '~/repositories/firestore/config'
+
+export const createUser = async (payload) => {
+  const { uid, displayName } = payload
+
+  await usersRef.doc(uid).set({
+    displayName,
+    profileText: null,
+    siteUrl: null,
+    image: {
+      id: null,
+      url: null
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp
+  })
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,16 +2,43 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone on the internet to view, edit, and delete
-    // all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // your app will lose access to your Firestore database
-    match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2020, 4, 10);
+    match /users/{userID} {
+      allow create: if isAuthenticated()
+                    && isUserAuthenticated(userID)
+                    && isUserValid(incomingData())
+                    && isCreateUserValid(incomingData());
+
+      function isUserValid(data) {
+        return data.size() == 6
+        && data.keys().hasAll(['displayName', 'profileText', 'siteUrl', 'image', 'createdAt', 'updatedAt'])
+        && validString(data.displayName, 1, 20)
+        && data.image.keys().hasAll(['id', 'url'])
+        && data.createdAt is timestamp
+        && data.updatedAt is timestamp;
+      }
+      function isCreateUserValid(data) {
+        return data.profileText == null
+        && data.siteUrl == null
+        && data.image.id == null
+        && data.image.url == null
+        && data.createdAt == data.updatedAt;
+      }
+    }
+
+    function isAuthenticated() {
+      return request.auth != null && request.auth.uid != null;
+    }
+
+    function isUserAuthenticated(userID) {
+      return request.auth.uid == userID;
+    }
+
+    function incomingData() {
+      return request.resource.data;
+    }
+
+    function validString(text, min, max) {
+      return text is string && min <= text.size() && text.size() <= max;
     }
   }
 }


### PR DESCRIPTION
## 📝 関連 issue
resolves #32 

## 🔨 変更内容
+ SignUpForm  Firestore 新規ユーザー作成クエリの呼び出しを追加
+ repositories/  Firestore に関するクエリロジックを定義するファイル群を配置するディレクトリを作成
  + /users/  ユーザー作成のクエリ createUser を追加
+ firestore.rules 上記クエリに対応するルールを追加

## 👀 確認手順
+ [ ] メール送信完了後、Firestore データモデルが作成されていることをコンソールより確認
