### PR TITLE
ログイン後の Firestore ユーザーモデルのクエリを追加ならびに vuex ロジックの追加

### DIFF
--- a/app/components/login/FormLogin.vue
+++ b/app/components/login/FormLogin.vue
@@ -89,18 +89,29 @@ export default {
 
       this.$store.commit('setIsLoading', true)
 
+      // firebase authentication sign in
       const result = await this.$auth
         .signInWithEmailAndPassword(email, password)
         .catch((error) => handleError(error))
 
       this.$store.commit('setIsLoading', false)
 
-      if (!result.user.emailVerified) {
+      if (!result) return
+
+      const { emailVerified, uid } = result.user
+
+      // verify email
+      if (!emailVerified) {
         alert(
           `メールアドレスの確認が完了していません。\n${email} 宛に送信された確認メールより、登録を完了してください。`
         )
+        return
       }
-      // Should be added login logic
+
+      // qurry firestore user and set state
+      await this.$store
+        .dispatch('login', { uid })
+        .catch((error) => handleError(error))
     }
   }
 }

--- a/app/repositories/firestore/users/index.js
+++ b/app/repositories/firestore/users/index.js
@@ -15,3 +15,17 @@ export const createUser = async (payload) => {
     updatedAt: timestamp
   })
 }
+
+export const getUser = async ({ uid }) => {
+  const doc = await usersRef.doc(uid).get()
+  if (!doc.exists) return
+
+  const { displayName, profileText, siteUrl, image } = doc.data()
+  return {
+    uid,
+    displayName,
+    profileText,
+    siteUrl,
+    image
+  }
+}

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -15,7 +15,7 @@ export const mutations = {
 }
 
 export const actions = {
-  async login({ commit }, uid) {
+  async login({ commit }, { uid }) {
     const user = await getUser({ uid })
     if (!user) return
 

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,9 +1,24 @@
+import { getUser } from '~/repositories/firestore/users'
+
 export const state = () => ({
-  isLoading: false
+  isLoading: false,
+  loginUser: null
 })
 
 export const mutations = {
   setIsLoading(state, payload) {
     state.isLoading = payload
+  },
+  setLoginUser(state, payload) {
+    state.loginUser = payload
+  }
+}
+
+export const actions = {
+  async login({ commit }, uid) {
+    const user = await getUser({ uid })
+    if (!user) return
+
+    commit('setLoginUser', user)
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,9 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     match /users/{userID} {
+      allow get: if isAuthenticated()
+                 && isUserAuthenticated(userID);
+
       allow create: if isAuthenticated()
                     && isUserAuthenticated(userID)
                     && isUserValid(incomingData())
@@ -16,6 +19,7 @@ service cloud.firestore {
         && data.createdAt is timestamp
         && data.updatedAt is timestamp;
       }
+
       function isCreateUserValid(data) {
         return data.profileText == null
         && data.siteUrl == null


### PR DESCRIPTION
## 📝 関連 issue
resolves #33 

## 🔨 変更内容
+ repositories/users/  ユーザーモデルの取得クエリ getUser を追加
+ firestore.rules 上記クエリのための get ルールを追加
+ store/index.js  上記クエリの呼び出しと、
+ FormLogin.vue  サインイン後の uid を用いた store.dispatch を追加

## 👀 確認手順
+ [ ] VueDevTools を使用して、/login よりログイン完了後に state.loginUser が更新されることを確認
