### PR TITLE
ローディングコンポーネント表示のロジックと文言の追加

### DIFF
--- a/app/components/TheLoading.vue
+++ b/app/components/TheLoading.vue
@@ -23,6 +23,7 @@
           </g>
         </g>
       </svg>
+      <p class="text">Loading...</p>
     </div>
   </transition>
 </template>
@@ -31,6 +32,7 @@
 .loader {
   pointer-events: none;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   position: fixed;
@@ -45,6 +47,13 @@
     color: $primary;
     width: 56px;
     height: 56px;
+  }
+
+  > .text {
+    @include caption;
+    color: $primary;
+    display: inline-block;
+    margin-top: 8px;
   }
 }
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="only-sp-view">
-    <nuxt />
+    <nuxt v-show="!isLoading" />
     <TheLoading v-show="isLoading" />
   </div>
 </template>


### PR DESCRIPTION
## 📝 関連 issue
resolves #64 

## 🔨 変更内容
+ layouts  isLoading === true の場合に nuxt コンポーネントを v-show によって非表示にする処理を追加
+ TheLoading  文言 Loading... を追加

## 👀 確認手順
+ [ ] VueDevTools の使用などにより (isLoading = true として) 各ページにおいて、ローディングコンポーネントの表示を確認
