### PR TITLE
レイアウトで読み込む共通コンポーネント TheAppBar を作成

### DIFF
--- a/app/assets/sprite/svg/navigation/arrow_back.svg
+++ b/app/assets/sprite/svg/navigation/arrow_back.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path fill="currentColor" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>

--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -1,0 +1,66 @@
+<template>
+  <section class="app-bar">
+    <nav class="nav leading">
+      <button class="icon" @click="$router.back()">
+        <svg-icon name="navigation/arrow_back" title="back" />
+      </button>
+    </nav>
+    <h1 class="title">
+      {{ title }}
+    </h1>
+  </section>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.app-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: $maxViewWidth;
+  position: fixed;
+  top: 0;
+  height: 44px;
+  padding: 4px 16px;
+  background: $white;
+  border: 1px solid $boundaryBlack;
+  z-index: 2;
+
+  > .title {
+    @include subhead;
+  }
+
+  > .nav {
+    display: flex;
+    align-items: center;
+    height: inherit;
+    position: absolute;
+
+    > .icon {
+      width: 24px;
+      height: 24px;
+
+      svg {
+        width: 100%;
+        height: 100%;
+        color: $gray;
+      }
+    }
+
+    &.leading {
+      left: 16px;
+    }
+  }
+}
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,21 +1,48 @@
 <template>
   <div class="only-sp-view">
+    <header>
+      <TheAppBar v-show="isAppBarVisible" :title="pageTitle" />
+    </header>
     <nuxt v-show="!isLoading" />
     <TheLoading v-show="isLoading" />
   </div>
 </template>
 
 <script>
+import TheAppBar from '~/components/TheAppBar'
 import TheLoading from '~/components/TheLoading'
 
 export default {
   components: {
+    TheAppBar,
     TheLoading
   },
 
   computed: {
     isLoading() {
       return this.$store.state.isLoading
+    },
+
+    isAppBarVisible() {
+      const excludedPaths = ['/']
+      return !excludedPaths.includes(this.$route.path)
+    },
+
+    pageTitle() {
+      const { path } = this.$route
+
+      switch (path) {
+        case '/signup/':
+          return 'ユーザー登録'
+        case '/login/':
+          return 'ログイン'
+        case '/terms/':
+          return '利用規約'
+        case '/policy/':
+          return 'プライバシーポリシー'
+        default:
+          return ''
+      }
     }
   }
 }


### PR DESCRIPTION
## 📝 関連 issue
resolves #63 

## 🔨 変更内容
+ svg ファイル navigation/arrow_back の追加
+ コンポーネント TheAppBar の作成
  + pageTitle を props として受け取り、表示する
+ layouts/default  上記コンポーネントの読み込みを追加
  + route.path に応じた props として渡すページタイトルについてロジックを追加
  + route.path に応じたコンポーネント表示切り替えのロジックを追加

## 👀 確認手順
+ [ ] ホーム以外のページで AppBar が表示されることを確認
  + ページタイトルならびにナビゲーションアイコンによるページバックを確認
