### PR TITLE
Firebase Authentication の情報を利用してログイン処理（ストアアクションの呼び出しを行う plugins の作成

### DIFF
--- a/app/plugins/client-init.js
+++ b/app/plugins/client-init.js
@@ -1,0 +1,7 @@
+export default async ({ app, store }) => {
+  const user = app.$auth.currentUser
+  if (!user || !user.emailVerified) return
+
+  // init state loginUser
+  await store.dispatch('login', { uid: user.uid })
+}

--- a/app/plugins/firebase/auth.js
+++ b/app/plugins/firebase/auth.js
@@ -8,7 +8,7 @@ export default (context, inject) =>
       currentUser: firebase.auth().currentUser
     })
 
-    inject('currentUser', observable.currentUser)
+    inject('firebase', observable)
 
     firebase.auth().onAuthStateChanged(() => {
       observable.currentUser = firebase.auth().currentUser

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -81,7 +81,8 @@ export default {
     '~/plugins/firebase/init.js',
     '~/plugins/firebase/analytics.js',
     '~/plugins/firebase/auth.js',
-    '~/plugins/firebase/inject.js'
+    '~/plugins/firebase/inject.js',
+    '~/plugins/client-init.js'
   ],
   /*
    ** Nuxt.js dev-modules


### PR DESCRIPTION
## 📝 関連 issue
resolves #67 

## 🔨 変更内容
+ plugins/client-init  Authentication uid を利用して、認証済みであれば Firestore クエリを行うストアアクションの呼び出しを追加
+ plugins/firebase/auth  inject 関数によって注入する値を修正

## 👀 確認手順
+ [ ] 認証済みのアカウントにおいて、アプリ初期化時（ブラウザ更新時）に state.LoginUser の初期化が行われることを確認
