### PR TITLE
最新リリースアルバム表示ページの作成

### DIFF
--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="app-bar">
-    <nav class="nav leading">
+    <nav v-if="backIconVisible" class="nav leading">
       <button class="icon" @click="$router.back()">
         <svg-icon name="navigation/arrow_back" title="back" />
       </button>
@@ -16,6 +16,10 @@ export default {
   props: {
     title: {
       type: String,
+      required: true
+    },
+    backIconVisible: {
+      type: Boolean,
       required: true
     }
   }

--- a/app/components/releases/ListReleases.vue
+++ b/app/components/releases/ListReleases.vue
@@ -1,0 +1,70 @@
+<template>
+  <ul class="list-releases">
+    <li
+      v-for="(release, index) in releases"
+      :key="`release-${index}`"
+      class="release-item"
+    >
+      <img
+        class="img"
+        :src="release.images[1].url"
+        :alt="`${release.name}の画像`"
+      />
+      <p class="title">
+        {{ release.name }}
+      </p>
+      <p class="artist">
+        {{ release.artists[0].name }}
+      </p>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      releases: []
+    }
+  },
+
+  async mounted() {
+    this.$store.commit('setIsLoading', true)
+
+    const api = this.$functions.httpsCallable('spotifyGetNewReleases')
+    const result = await api().catch((error) => this.$nuxt.error(error))
+
+    this.$store.commit('setIsLoading', false)
+
+    if (!result) return
+    this.releases = result.data
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.list-releases {
+  display: flex;
+  flex-wrap: wrap;
+
+  > .release-item {
+    margin: 0 0 16px 16px;
+    width: calc(50% - 24px);
+
+    > .img {
+      width: 100%;
+      border: 1px solid $boundaryBlack;
+      border-radius: 8px;
+    }
+
+    > .title {
+      margin-top: -4px;
+    }
+
+    > .artist {
+      line-height: 1;
+      color: $gray;
+    }
+  }
+}
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="only-sp-view">
     <header>
-      <TheAppBar v-show="isAppBarVisible" :title="pageTitle" />
+      <TheAppBar
+        v-show="isAppBarVisible"
+        :title="pageTitle"
+        :back-icon-visible="backIconVisible"
+      />
     </header>
     <nuxt v-show="!isLoading" />
     <TheLoading v-show="isLoading" />
@@ -28,6 +32,11 @@ export default {
       return !excludedPaths.includes(this.$route.path)
     },
 
+    backIconVisible() {
+      const excludedPaths = ['/releases/']
+      return !excludedPaths.includes(this.$route.path)
+    },
+
     pageTitle() {
       const { path } = this.$route
 
@@ -36,6 +45,8 @@ export default {
           return 'ユーザー登録'
         case '/login/':
           return 'ログイン'
+        case '/releases/':
+          return '最新リリース'
         case '/terms/':
           return '利用規約'
         case '/policy/':

--- a/app/pages/releases.vue
+++ b/app/pages/releases.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container">
+    <ListReleases />
+  </div>
+</template>
+
+<script>
+import ListReleases from '~/components/releases/ListReleases'
+
+export default {
+  components: {
+    ListReleases
+  },
+
+  head() {
+    return {
+      title: 'リリース'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  margin-top: 56px;
+}
+</style>


### PR DESCRIPTION
## 📝 関連 issue
related to #70 

## 🔨 変更内容
ListReleases
+ Spotify releases オブジェクトの表示コンポーネント作成
+ Cloud Functions の呼び出しロジック追加

/releases 
+ ページ作成ならびに上記コンポーネント表示

layouts/defaut, TheAppBar  
+ 上記ページ作成に伴いページタイトルならびにナビアイコンの表示切り替えロジックを追加

## 👀 確認手順
+ [ ] /releases/ の表示を確認
