### PR TITLE
最新リリースオブジェクトについて vuex ロジックを追加

### DIFF
--- a/app/components/releases/ListReleases.vue
+++ b/app/components/releases/ListReleases.vue
@@ -29,6 +29,11 @@ export default {
   },
 
   async mounted() {
+    const storeReleases = this.$store.state.spotify.releases
+    if (storeReleases.length) {
+      this.releases = storeReleases
+    }
+
     this.$store.commit('setIsLoading', true)
 
     const api = this.$functions.httpsCallable('spotifyGetNewReleases')
@@ -37,7 +42,10 @@ export default {
     this.$store.commit('setIsLoading', false)
 
     if (!result) return
-    this.releases = result.data
+
+    const releases = result.data
+    this.releases = releases
+    this.$store.commit('spotify/setReleases', releases)
   }
 }
 </script>

--- a/app/store/spotify.js
+++ b/app/store/spotify.js
@@ -1,0 +1,9 @@
+export const state = () => ({
+  releases: []
+})
+
+export const mutations = {
+  setReleases(state, payload) {
+    state.releases = payload
+  }
+}


### PR DESCRIPTION
## 📝 関連 issue
resolves #70 

## 🔨 変更内容
store/spotify
+ ストア作成ならびに state releases の追加
ListReleaes 
+ API コールの前に state をデータにマージする処理を追加
+ API データのストアコミット追加

## 👀 確認手順
+ [ ] VueDevTools より /releases の vuex ロジックを確認
