### PR TITLE
Spotify アルバム個別データの取得 API (Cloud Functions) 作成

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,5 @@
 const funcs = {
+  spotifyGetAlbum: './spotify/get-album',
   spotifyGetNewReleases: './spotify/get-new-releases'
 }
 

--- a/functions/src/spotify/get-album.ts
+++ b/functions/src/spotify/get-album.ts
@@ -1,0 +1,101 @@
+import * as functions from 'firebase-functions'
+import axios, { AxiosRequestConfig } from 'axios'
+
+const CLIENT_ID = functions.config().spotify.client_id
+const CLIENT_SECRET = functions.config().spotify.client_secret
+
+interface RequestData {
+  albumId: string
+}
+interface AuthResult {
+  data: AccessToken
+}
+interface AccessToken {
+  access_token: string
+}
+interface Releases {
+  data: Album
+}
+interface Album {
+  album_type: string
+  artists: Array<{key: string}>
+  external_urls: {key: string}
+  id: string
+  images: string[]
+  name: string
+  release_date: string
+  tracks: { items: Track[] }
+}
+interface Track {
+  artists: Array<{key: string}>
+  external_urls: {key: string}
+  id: string
+  name: string
+  preview_url: string
+  track_number: number
+}
+
+const getToken = async (): Promise<AuthResult> => {
+  const auth = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64')
+  const config: AxiosRequestConfig = {
+    method: 'post',
+    url: 'https://accounts.spotify.com/api/token?grant_type=client_credentials',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Authorization': `Basic ${auth}`
+    },
+  }
+  return await axios.request(config)
+}
+
+const getAlbum = async (id: string): Promise<Releases> => {
+  const token = await getToken()
+  const auth = token.data.access_token
+  const config: AxiosRequestConfig = {
+    method: 'get',
+    url: `https://api.spotify.com/v1/albums/${id}?market=JP`,
+    headers: {
+      'Authorization': `Bearer ${auth}`,
+      'Accept-Language': 'ja;q=1'
+    }
+  }
+  return await axios.request(config)
+}
+
+module.exports = functions
+  .region('asia-northeast1')
+  .https.onCall(async (data: RequestData) => {
+    const result = await getAlbum(data.albumId)
+    const {
+      album_type,
+      artists,
+      external_urls,
+      id,
+      images,
+      name,
+      release_date
+    } = result.data
+
+    const tracks = result.data.tracks.items.map((track: Track) => {
+      // process return value
+      return{
+        artists: track.artists,
+        external_urls: track.external_urls,
+        id: track.id,
+        name: track.name,
+        preview_url: track.preview_url,
+        track_number: track.track_number
+      }
+    })
+
+    return {
+      album_type,
+      artists,
+      external_urls,
+      id,
+      images,
+      name,
+      release_date,
+      tracks
+    }
+  })


### PR DESCRIPTION
## 📝 関連 issue
resolves #75 

## 🔨 変更内容
functions/
+ getSpotifyAlbum 関数の作成
  + Client から渡す `albumId` により Spotify Albums オブジェクトを取得するロジックを追加
+ index.ts 関数デプロイの登録

## 👀 確認手順
+ [ ] アプリクライアントから関数の呼び出しを確認

## 参考
[Get an Album | Spotify API](https://developer.spotify.com/documentation/web-api/reference/albums/get-album/)