### PR TITLE
アルバム個別ページに vuex ロジックの追加

### DIFF
--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -77,14 +77,19 @@ export default {
   async mounted() {
     if (!this.albumId) return
 
+    const storeAlbum = this.$store.getters['spotify/getAlbumById'](this.albumId)
+    if (storeAlbum) return (this.album = storeAlbum)
+
     this.$store.commit('setIsLoading', true)
 
     const api = this.$functions.httpsCallable('spotifyGetAlbum')
     const result = await api({ albumId: this.albumId }).catch((error) =>
       this.nuxt.error(error)
     )
-    this.album = result.data
+    const album = result.data
 
+    this.album = album
+    this.$store.commit('spotify/setAlbum', album)
     this.$store.commit('setIsLoading', false)
   },
 

--- a/app/store/spotify.js
+++ b/app/store/spotify.js
@@ -1,9 +1,19 @@
 export const state = () => ({
-  releases: []
+  releases: [],
+  albums: []
 })
+
+export const getters = {
+  getAlbumById: (state) => (id) => {
+    return state.albums.find((album) => album.id === id)
+  }
+}
 
 export const mutations = {
   setReleases(state, payload) {
     state.releases = payload
+  },
+  setAlbum(state, payload) {
+    state.albums = [payload, ...state.albums]
   }
 }


### PR DESCRIPTION
## 📝 関連 issue
resolves #74 

## 🔨 変更内容
albums/_albumId
+ 取得した API データのストアコミットを追加
+ 取得済みの（ストアに存在する）データに関してはクエリを行わないようロジックを追加

store/spotify
+ state.albums の追加ならびに id による取得 (getters)、mutations を追加

## 👀 確認手順
+ [ ] アルバム個別ページ表示において、取得済みのデータが直ちに表示されることを確認
