### PR TITLE
ログイン状態に応じたルーティングミドルウェアの作成

### DIFF
--- a/app/components/releases/ListReleases.vue
+++ b/app/components/releases/ListReleases.vue
@@ -34,9 +34,9 @@ export default {
     const storeReleases = this.$store.state.spotify.releases
     if (storeReleases.length) {
       this.releases = storeReleases
+    } else {
+      this.$store.commit('setIsLoading', true)
     }
-
-    this.$store.commit('setIsLoading', true)
 
     const api = this.$functions.httpsCallable('spotifyGetNewReleases')
     const result = await api().catch((error) => this.$nuxt.error(error))

--- a/app/middleware/valid-login.js
+++ b/app/middleware/valid-login.js
@@ -1,0 +1,18 @@
+export default ({ store, route, redirect }) => {
+  const loginUser = store.state.loginUser
+  const isLoggedIn = !!loginUser
+
+  const validPath = (paths) => {
+    const validate = (path) => route.path === path
+    return !!paths.find((path) => validate(path))
+  }
+
+  const { albumId } = route.params
+  const pathsShouldLoggedIn = ['/releases/', `/albums/${albumId}/`]
+  const pathsShouldNotLoggedIn = ['/', '/signup/', '/login/']
+
+  if (validPath(pathsShouldLoggedIn) && !isLoggedIn) return redirect('/')
+  if (validPath(pathsShouldNotLoggedIn) && isLoggedIn) {
+    return redirect('/releases/')
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,6 +66,12 @@ export default {
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
+  //
+  // router
+  //
+  router: {
+    middleware: ['valid-login']
+  },
   /*
    ** Customize the progress-bar color
    */


### PR DESCRIPTION
## 📝 関連 issue
resolves #69 

## 🔨 変更内容
middleware/valid-login
+ ログイン状態に応じたルーティングを作成
  + /, /signup/, /login/ は未ログイン時のみアクセスを許可する
  + /releases/, /albums/ はログイン済みの場合のみアクセス許可する

nuxt.config
+ 上記 middleware を登録

ListReleases  
+ すでにリスト取得済みの場合、ローディングを表示しないよう変更

## 👀 確認手順
+ [ ] 未ログインで /releases/ ect. のルートにアクセスし、リダイレクトされることを確認
+ [ ] ログイン済みで /login/ etc. のルートにアクセスし、リダイレクトされることを確認
