### PR TITLE
pages/ 以下 SFC の Typescript 移行

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,21 +29,24 @@
   </section>
 </template>
 
-<script>
-import BaseButton from '~/components/form/BaseButton'
+<script lang="ts">
+import { MetaInfo } from 'vue-meta'
+import Vue from 'vue'
 
-export default {
+import BaseButton from '~/components/form/BaseButton.vue'
+
+export default Vue.extend({
   components: {
     BaseButton
   },
 
-  head() {
+  head(): MetaInfo {
     return {
       titleTemplate: '',
       title: 'ShareTune'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -7,20 +7,23 @@
   </div>
 </template>
 
-<script>
-import FormLogin from '~/components/login/FormLogin'
+<script lang="ts">
+import { MetaInfo } from 'vue-meta'
+import Vue from 'vue'
 
-export default {
+import FormLogin from '~/components/login/FormLogin.vue'
+
+export default Vue.extend({
   components: {
     FormLogin
   },
 
-  head() {
+  head(): MetaInfo {
     return {
       title: 'ログイン'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/policy.vue
+++ b/app/pages/policy.vue
@@ -223,14 +223,17 @@
   </article>
 </template>
 
-<script>
-export default {
-  head() {
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+
+export default Vue.extend({
+  head(): MetaInfo {
     return {
       title: 'プライバシーポリシー'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/releases.vue
+++ b/app/pages/releases.vue
@@ -4,20 +4,23 @@
   </div>
 </template>
 
-<script>
-import ListReleases from '~/components/releases/ListReleases'
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 
-export default {
+import ListReleases from '~/components/releases/ListReleases.vue'
+
+export default Vue.extend({
   components: {
     ListReleases
   },
 
-  head() {
+  head(): MetaInfo {
     return {
       title: 'リリース'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="container">
-    <section v-if="signUpCompleted" class="complete">
+    <section v-if="doneSignUp" class="complete">
       <h1>確認メールを送信しました</h1>
       <p>{{ email }} 宛に確認メールを送信しました。</p>
       <p>メールの内容を確認して、登録を完了してください。</p>
     </section>
-    <FormSignUp v-if="!signUpCompleted" @onCompleteSignUp="email = $event" />
-    <p v-if="!signUpCompleted" class="caption">
+    <FormSignUp v-if="!doneSignUp" @onCompleteSignUp="email = $event" />
+    <p v-if="!doneSignUp" class="caption">
       <nuxt-link to="/terms/">利用規約</nuxt-link>
       と
       <nuxt-link to="/policy/">プライバシーポリシー</nuxt-link>
@@ -19,32 +19,34 @@
   </div>
 </template>
 
-<script>
-import FormSignUp from '~/components/signup/FormSignUp'
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 
-export default {
+import FormSignUp from '~/components/signup/FormSignUp.vue'
+
+export default Vue.extend({
   components: {
     FormSignUp
   },
 
   data() {
     return {
-      email: ''
+      email: '' as string
     }
   },
-
   computed: {
-    signUpCompleted() {
+    doneSignUp(): boolean {
       return !!this.email
     }
   },
 
-  head() {
+  head(): MetaInfo {
     return {
       title: 'ユーザー登録'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -35,6 +35,7 @@ export default Vue.extend({
       email: '' as string
     }
   },
+
   computed: {
     doneSignUp(): boolean {
       return !!this.email

--- a/app/pages/terms.vue
+++ b/app/pages/terms.vue
@@ -309,14 +309,17 @@
   </article>
 </template>
 
-<script>
-export default {
-  head() {
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+
+export default Vue.extend({
+  head(): MetaInfo {
     return {
       title: '利用規約'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## 📝 関連 issue
related to #92 

## 🔨 変更内容

pages/ 以下の各 .vue ファイル (/index, /login, /signup, /terms, /policy, /releases) について以下の対応
- `<script>` を `<script "lang=ts">` に変更
- コンポーネントロジックを Vue.extend の記述に変更
- vue-meta より 型 `MetaInfo` をインポートし、 head() プロパティに付与
- /signup に関して、data() および computed() に型を付与
  - 合わせて変数名をよりセマンティックな命名に変更

## 👀 確認手順
+ [ ] アプリの動作が以前と変わらず問題ないことを確認
+ [ ] 実装コードを確認
