### PR TITLE
layouts 関係 およびアルバム個別ページ SFC の Typescript 対応

### DIFF
--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -11,11 +11,14 @@
   </section>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import { PageTitle } from '~/layouts/default.vue'
+
+export default Vue.extend({
   props: {
     title: {
-      type: String,
+      type: String as PropType<PageTitle>,
       required: true
     },
     backIconVisible: {
@@ -23,7 +26,7 @@ export default {
       required: true
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/components/TheLoading.vue
+++ b/app/components/TheLoading.vue
@@ -28,6 +28,11 @@
   </transition>
 </template>
 
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({})
+</script>
+
 <style lang="scss" scoped>
 .loader {
   pointer-events: none;

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -12,32 +12,41 @@
   </div>
 </template>
 
-<script>
-import TheAppBar from '~/components/TheAppBar'
-import TheLoading from '~/components/TheLoading'
+<script lang="ts">
+import Vue from 'vue'
+import TheAppBar from '~/components/TheAppBar.vue'
+import TheLoading from '~/components/TheLoading.vue'
 
-export default {
+type pageTitle =
+  | ''
+  | 'ユーザー登録'
+  | 'ログイン'
+  | '最新リリース'
+  | '利用規約'
+  | 'プライバシーポリシー'
+
+export default Vue.extend({
   components: {
     TheAppBar,
     TheLoading
   },
 
   computed: {
-    isLoading() {
+    isLoading(): boolean {
       return this.$store.state.isLoading
     },
 
-    isAppBarVisible() {
+    isAppBarVisible(): boolean {
       const excludedPaths = ['/']
       return !excludedPaths.includes(this.$route.path)
     },
 
-    backIconVisible() {
+    backIconVisible(): boolean {
       const excludedPaths = ['/releases/']
       return !excludedPaths.includes(this.$route.path)
     },
 
-    pageTitle() {
+    pageTitle(): pageTitle {
       const { path } = this.$route
 
       switch (path) {
@@ -56,7 +65,7 @@ export default {
       }
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -17,7 +17,7 @@ import Vue from 'vue'
 import TheAppBar from '~/components/TheAppBar.vue'
 import TheLoading from '~/components/TheLoading.vue'
 
-type pageTitle =
+export type PageTitle =
   | ''
   | 'ユーザー登録'
   | 'ログイン'
@@ -46,7 +46,7 @@ export default Vue.extend({
       return !excludedPaths.includes(this.$route.path)
     },
 
-    pageTitle(): pageTitle {
+    pageTitle(): PageTitle {
       const { path } = this.$route
 
       switch (path) {

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -12,33 +12,40 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { MetaInfo } from 'vue-meta'
+import Vue, { PropType } from 'vue'
+
+interface Error {
+  statusCode: number
+}
+
+export default Vue.extend({
   props: {
     error: {
-      type: Object,
+      type: Object as PropType<Error>,
       required: true
     }
   },
 
   computed: {
-    statusCode() {
-      return (this.error && this.error.statusCode) || 500
+    statusCode(): number {
+      return this.error?.statusCode ?? 500
     },
 
-    message() {
+    message(): string {
       return this.statusCode === 404
         ? 'ページが見つかりません'
         : 'エラーが発生しました'
     }
   },
 
-  head() {
+  head(): MetaInfo {
     return {
       title: this.message
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
       return this.error?.statusCode ?? 500
     },
 
-    message(): string {
+    message(): 'ページが見つかりません' | 'エラーが発生しました' {
       return this.statusCode === 404
         ? 'ページが見つかりません'
         : 'エラーが発生しました'

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -90,13 +90,13 @@ export default Vue.extend({
 
   computed: {
     releaseDate(): string {
-      if (!this.album) return ''
+      if (this.album === null) return ''
 
       return dayjs(this.album.release_date).format('YYYY年MM月DD日')
     },
 
     title(): string {
-      if (!this.album) return ''
+      if (this.album === null) return ''
 
       const albumName = this.album.name ?? ''
       const albumArtist = this.album.artists[0].name ?? ''
@@ -108,9 +108,9 @@ export default Vue.extend({
     const albumId = this.albumId
     if (!albumId) return
 
-    const storeAlbum: Album = this.$store.getters['spotify/getAlbumById'](
-      albumId
-    )
+    const storeAlbum: Album | undefined = this.$store.getters[
+      'spotify/getAlbumById'
+    ](albumId)
     if (storeAlbum) {
       this.album = storeAlbum
       return

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -42,7 +42,7 @@
       </ul>
     </section>
     <p class="date">
-      <time>リリース: {{ formatDate(album.release_date) }}</time>
+      <time>リリース: {{ releaseDate }}</time>
     </p>
   </article>
 </template>
@@ -76,6 +76,10 @@ interface Artists {
   name: string
 }
 
+interface Response {
+  data: Album
+}
+
 export default Vue.extend({
   data() {
     return {
@@ -85,34 +89,40 @@ export default Vue.extend({
   },
 
   computed: {
-    formatDate() {
-      return (date: string) => {
-        return dayjs(date).format('YYYY年MM月DD日')
-      }
+    releaseDate(): string {
+      if (!this.album) return ''
+
+      return dayjs(this.album.release_date).format('YYYY年MM月DD日')
     },
 
     title(): string {
       if (!this.album) return ''
 
-      const albumName = this.album ? this.album.name : ''
-      const albumArtist = this.album ? this.album.artists[0].name : ''
+      const albumName = this.album.name ?? ''
+      const albumArtist = this.album.artists[0].name ?? ''
       return `${albumArtist}の${albumName}`
     }
   },
 
   async mounted(): Promise<void> {
-    if (!this.albumId) return
+    const albumId = this.albumId
+    if (!albumId) return
 
-    const storeAlbum = this.$store.getters['spotify/getAlbumById'](this.albumId)
-    if (storeAlbum) return (this.album = storeAlbum)
+    const storeAlbum: Album = this.$store.getters['spotify/getAlbumById'](
+      albumId
+    )
+    if (storeAlbum) {
+      this.album = storeAlbum
+      return
+    }
 
     this.$store.commit('setIsLoading', true)
 
     const api = this.$functions.httpsCallable('spotifyGetAlbum')
-    const result = await api({ albumId: this.albumId }).catch((error: Error) =>
+    const response: Response = await api({ albumId }).catch((error: Error) =>
       this.$nuxt.error(error)
     )
-    const album = result.data
+    const album = response.data
 
     this.album = album
     this.$store.commit('spotify/setAlbum', album)


### PR DESCRIPTION
## 📝 関連 issue
related to #92 

## 🔨 変更内容
layouts/default, layouts/error, TheLoading, TheAppBar の Typescript 対応のためのリファクタ
- `<script lang=ts>` に変更
- computed() および props の各値に型を付与
- Nullish Coalescing, Optional Chaining を用いた、ロジックのリファクタ

pages/_albumId
- API レスポンスに対して型の宣言を追加
- computed() を変数を受け取らない形および Nullish Coalescing を使用したロジックに変更

## 👀 確認手順
+ [ ] Typescript のエラーがないことを確認
+ [ ] アプリの挙動が以前と変わらず問題のないことを確認
