### PR TITLE
componets/ 以下の SFC Typescript 対応

### DIFF
--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -13,7 +13,14 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue'
-import { PageTitle } from '~/layouts/default.vue'
+
+export type PageTitle =
+  | ''
+  | 'ユーザー登録'
+  | 'ログイン'
+  | '最新リリース'
+  | '利用規約'
+  | 'プライバシーポリシー'
 
 export default Vue.extend({
   props: {

--- a/app/components/form/BaseButton.vue
+++ b/app/components/form/BaseButton.vue
@@ -8,8 +8,10 @@
   </button>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
   props: {
     label: {
       type: String,
@@ -20,7 +22,7 @@ export default {
       required: true
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/components/form/BaseInputText.vue
+++ b/app/components/form/BaseInputText.vue
@@ -12,8 +12,10 @@
   </label>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
   props: {
     label: {
       type: String,
@@ -42,12 +44,12 @@ export default {
 
   data() {
     return {
-      value: ''
+      value: '' as string
     }
   },
 
   watch: {
-    value(newVal) {
+    value(newVal: string) {
       this.$emit('onChangeValue', newVal)
     }
   },
@@ -55,7 +57,7 @@ export default {
   mounted() {
     if (this.currentValue) this.value = this.currentValue
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/components/form/BaseTextarea.vue
+++ b/app/components/form/BaseTextarea.vue
@@ -11,8 +11,10 @@
   </label>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
   props: {
     label: {
       type: String,
@@ -34,12 +36,12 @@ export default {
 
   data() {
     return {
-      value: ''
+      value: '' as string
     }
   },
 
   watch: {
-    value(newVal) {
+    value(newVal: string) {
       this.$emit('onChangeValue', newVal)
     }
   },
@@ -47,7 +49,7 @@ export default {
   mounted() {
     if (this.currentValue) this.value = this.currentValue
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/components/login/FormLogin.vue
+++ b/app/components/login/FormLogin.vue
@@ -25,11 +25,24 @@
   </form>
 </template>
 
-<script>
-import BaseInputText from '~/components/form/BaseInputText'
-import BaseButton from '~/components/form/BaseButton'
+<script lang="ts">
+import Vue from 'vue'
 
-export default {
+import BaseInputText from '~/components/form/BaseInputText.vue'
+import BaseButton from '~/components/form/BaseButton.vue'
+
+interface LoginError extends Error {
+  code: string
+}
+
+interface Result {
+  user: {
+    uid: string
+    emailVerified: boolean
+  }
+}
+
+export default Vue.extend({
   components: {
     BaseInputText,
     BaseButton
@@ -37,25 +50,25 @@ export default {
 
   data() {
     return {
-      email: '',
-      password: ''
+      email: '' as string,
+      password: '' as string
     }
   },
 
   computed: {
-    isEmailValid() {
+    isEmailValid(): boolean {
       const email = this.email
       const regexp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
       return !!email && regexp.test(email)
     },
 
-    isPassValid() {
+    isPassValid(): boolean {
       const pass = this.password
       const regexp = /^([a-z0-9!-/:-@¥[-`{-~]){6,32}$/i
       return !!pass && regexp.test(pass)
     },
 
-    isFormValid() {
+    isFormValid(): boolean {
       const { isEmailValid, isPassValid } = this
       return isEmailValid && isPassValid
     }
@@ -67,7 +80,7 @@ export default {
 
       const { email, password } = this
 
-      const handleError = (error) => {
+      const handleError = (error: LoginError) => {
         switch (error.code) {
           case 'auth/invalid-email':
             alert(`${email}は無効なメールアドレスです。`)
@@ -90,13 +103,13 @@ export default {
       this.$store.commit('setIsLoading', true)
 
       // firebase authentication sign in
-      const result = await this.$auth
+      const result: Result = await this.$auth
         .signInWithEmailAndPassword(email, password)
-        .catch((error) => handleError(error))
+        .catch((error: LoginError) => handleError(error))
 
       this.$store.commit('setIsLoading', false)
 
-      if (!result) return
+      if (!result?.user) return
 
       const { emailVerified, uid } = result.user
 
@@ -111,10 +124,10 @@ export default {
       // qurry firestore user and set state
       await this.$store
         .dispatch('login', { uid })
-        .catch((error) => handleError(error))
+        .catch((error: LoginError) => handleError(error))
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -14,16 +14,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import TheAppBar from '~/components/TheAppBar.vue'
+import TheAppBar, { PageTitle } from '~/components/TheAppBar.vue'
 import TheLoading from '~/components/TheLoading.vue'
-
-export type PageTitle =
-  | ''
-  | 'ユーザー登録'
-  | 'ログイン'
-  | '最新リリース'
-  | '利用規約'
-  | 'プライバシーポリシー'
 
 export default Vue.extend({
   components: {


### PR DESCRIPTION
## 📝 関連 issue
related to #92 

## 🔨 変更内容
componets/form/ 以下の SFC および FormLogin.vue, FormSignUp.vue の Typescript 対応
- `<script lang=ts>` に変更
- data(), computed() などの各返り値ならびに error オブジェクトに型を付与

可読性などの観点から、TheAppBar.vue で用いる PropType PageTitle の記述を親コンポーネント内から子コンポーネント内に変更

## 👀 確認手順
+ [ ] アプリの挙動が以前と変わらず、問題のないことを確認
+ [ ] 実装コードを確認
