### PR TITLE
functions/src の型宣言を型定義ファイルに移行し、Nuxt/app の API データ型宣言を前述のファイルから import するよう変更

### DIFF
--- a/app/types/spotify-api.d.ts
+++ b/app/types/spotify-api.d.ts
@@ -1,35 +1,4 @@
-type Item = {
-  album_type: string
-  artists: { key: string }[]
-  external_urls: { key: string }
-  id: string
-  images: string[]
-  name: string
-  release_date: string
-}
+import { Item, Track, Album } from '../../functions/src/types/spotify-api'
 
 export type Albums = readonly Item[]
-
-type Artists = {
-  name: string
-}
-
-type Track = {
-  artists: { key: string }[]
-  external_urls: { key: string }
-  id: string
-  name: string
-  preview_url: string
-  track_number: number
-}
-
-export type Album = {
-  album_type: string
-  artists: Artists[]
-  external_urls: { key: string }
-  id: string
-  images: string[]
-  name: string
-  release_date: string
-  tracks: { items: Track[] }
-}
+export { Item, Track, Album }

--- a/functions/src/spotify/get-album.ts
+++ b/functions/src/spotify/get-album.ts
@@ -1,38 +1,15 @@
 import * as functions from 'firebase-functions'
 import axios, { AxiosRequestConfig } from 'axios'
+import { AuthResult, Album, Track } from '../types/spotify-api'
 
 const CLIENT_ID = functions.config().spotify.client_id
 const CLIENT_SECRET = functions.config().spotify.client_secret
 
 type RequestData = {
-  albumId: string
+  readonly albumId: string
 }
-type AuthResult = {
-  data: AccessToken
-}
-type AccessToken = {
-  access_token: string
-}
-type Releases = {
+type SpotifyAlbum = {
   data: Album
-}
-type Album = {
-  album_type: string
-  artists: { key: string }[]
-  external_urls: { key: string }
-  id: string
-  images: string[]
-  name: string
-  release_date: string
-  tracks: { items: Track[] }
-}
-type Track = {
-  artists: { key: string }[]
-  external_urls: { key: string }
-  id: string
-  name: string
-  preview_url: string
-  track_number: number
 }
 
 const getToken = async (): Promise<AuthResult> => {
@@ -49,7 +26,7 @@ const getToken = async (): Promise<AuthResult> => {
   return response
 }
 
-const getAlbum = async (id: string): Promise<Releases> => {
+const getAlbum = async (id: string): Promise<SpotifyAlbum> => {
   const token = await getToken()
   const auth = token.data.access_token
   const config: AxiosRequestConfig = {

--- a/functions/src/spotify/get-new-releases.ts
+++ b/functions/src/spotify/get-new-releases.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions'
 import axios, { AxiosRequestConfig } from 'axios'
+import { AuthResult, Albums, Item } from '../types/spotify-api'
 
 const CLIENT_ID = functions.config().spotify.client_id
 const CLIENT_SECRET = functions.config().spotify.client_secret
@@ -7,26 +8,8 @@ const CLIENT_SECRET = functions.config().spotify.client_secret
 type RequestData = {
   offset: number
 }
-type AuthResult = {
-  data: AccessToken
-}
-type AccessToken = {
-  access_token: string
-}
 type Releases = {
   data: Albums
-}
-type Albums = {
-  albums: { items: Item[] }
-}
-type Item = {
-  album_type: string
-  artists: { key: string }[]
-  external_urls: { key: string }
-  id: string
-  images: string[]
-  name: string
-  release_date: string
 }
 
 const getToken = async (): Promise<AuthResult> => {

--- a/functions/src/types/spotify-api.d.ts
+++ b/functions/src/types/spotify-api.d.ts
@@ -1,0 +1,39 @@
+export type AuthResult = {
+  readonly data: { access_token: string }
+}
+
+type Artists = { name: string }
+
+type Item = {
+  album_type: string
+  artists: readonly Artists[]
+  external_urls: { key: string }
+  id: string
+  images: string[]
+  name: string
+  release_date: string
+}
+
+type Albums = {
+  albums: { items: readonly Item[] }
+}
+
+export type Track = {
+  artists: readonly Artists[]
+  external_urls: { key: string }
+  id: string
+  name: string
+  preview_url: string
+  track_number: number
+}
+
+type Album = {
+  album_type: string
+  artists: readonly Artists[]
+  external_urls: { key: string }
+  id: string
+  images: string[]
+  name: string
+  release_date: string
+  tracks: { items: readonly Track[] }
+}


### PR DESCRIPTION
## 🔨 変更内容
+ 型定義ファイル `functions/src/types/spotify-api.d.ts` の作成
  + src/ 以下の型宣言を上記ファイルより import するようリファクタ
+ クライアント（Nuxt）側型定義ファイルにおいて、上記ファイルから型を import するようリファクタ

## 👀 確認手順
+ [ ] API データの各型を参照しているファイルにおいて、型解析が正しく行われていることを確認
