### PR TITLE
Firestore クエリ周りの TypeScript 対応

### DIFF
--- a/app/repositories/firestore/config.ts
+++ b/app/repositories/firestore/config.ts
@@ -6,5 +6,5 @@ const fieldVal = firebase.firestore.FieldValue
 export const timestamp = fieldVal.serverTimestamp()
 
 // reference of collection
-const ref = (ref) => db.collection(ref)
+const ref = (ref: 'users') => db.collection(ref)
 export const usersRef = ref('users')

--- a/app/repositories/firestore/users/index.js
+++ b/app/repositories/firestore/users/index.js
@@ -1,4 +1,4 @@
-import { usersRef, timestamp } from '~/repositories/firestore/config'
+import { usersRef, timestamp } from '~/repositories/firestore/config.ts'
 
 export const createUser = async (payload) => {
   const { uid, displayName } = payload

--- a/app/repositories/firestore/users/index.ts
+++ b/app/repositories/firestore/users/index.ts
@@ -1,6 +1,12 @@
 import { usersRef, timestamp } from '~/repositories/firestore/config.ts'
+import { User } from '~/types/firestore/users'
 
-export const createUser = async (payload) => {
+type Payload = {
+  uid: string
+  displayName: string
+}
+
+export const createUser = async (payload: Payload) => {
   const { uid, displayName } = payload
 
   await usersRef.doc(uid).set({
@@ -16,11 +22,12 @@ export const createUser = async (payload) => {
   })
 }
 
-export const getUser = async ({ uid }) => {
+export const getUser = async ({ uid }: { uid: string }) => {
   const doc = await usersRef.doc(uid).get()
   if (!doc.exists) return
 
-  const { displayName, profileText, siteUrl, image } = doc.data()
+  const { displayName, profileText, siteUrl, image } = doc.data() as User
+
   return {
     uid,
     displayName,

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,9 +1,10 @@
 import { ActionTree, MutationTree } from 'vuex'
 import { getUser } from '~/repositories/firestore/users'
+import { User } from '~/types/firestore/users'
 
 export const state = () => ({
   isLoading: false as boolean,
-  loginUser: null as any
+  loginUser: null as null | Readonly<User>
 })
 
 export type RootState = ReturnType<typeof state>

--- a/app/types/firestore/users.d.ts
+++ b/app/types/firestore/users.d.ts
@@ -1,0 +1,11 @@
+export type User = {
+  displayName: string
+  profileText: null | string
+  siteUrl: null | string
+  image: {
+    id: null | string
+    url: null | string
+  }
+  createdAt: firebase.firestore.FieldValue
+  updatedAt: firebase.firestore.FieldValue
+}


### PR DESCRIPTION
## 📝 関連 issue
resolves #109 

## 🔨 変更内容
型定義ファイル `types/firestore/user.d.ts` 追加
+ User モデルの型定義を追加

repositories/firestore/
+ 拡張子を .js から .ts へ変更
+ 各関数の引数等に型宣言を追加

store/index.ts
+ state.loginUser に対し、Readonly<User> 型を追加

## 👀 確認手順
+ [ ] Firestore クエリ関数および state.loginUser に対し、型解析が動作していることを確認
