### PR TITLE
ブックマークアイコンの初期状態（ブックマーク済みであるかどうか）を取得するクエリ追加

### DIFF
--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -128,6 +128,8 @@ export default Vue.extend({
     bookmark() {
       this.isFavorite = !this.isFavorite
 
+      if (!this.isFavorite) return
+
       const album = this.album as Album
       const data = {
         uid: this.$firebase.currentUser?.uid as string,

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -104,11 +104,13 @@ export default Vue.extend({
   async mounted(): Promise<void> {
     const albumId = this.albumId
     const uid = this.$firebase.currentUser?.uid
+
     // query this album is bookmarked
     if (uid) {
       const isBookmarked = await getIsBookmarked({ uid, albumId })
       this.isBookmarked = isBookmarked
     }
+
     // if store state exists merge state
     const storeAlbum: Album | undefined = this.$store.getters[
       'spotify/getAlbumById'
@@ -117,6 +119,7 @@ export default Vue.extend({
       this.album = storeAlbum
       return
     }
+
     // fetch from Spotify API
     this.$store.commit('setIsLoading', true)
 

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
   },
 
   methods: {
-    bookmark() {
+    bookmark(): void {
       // switch flag
       this.isBookmarked = !this.isBookmarked
 

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -6,6 +6,11 @@ type Payload = {
   album: Bookmark['album']
 }
 
+type Query = {
+  uid: string
+  albumId: string
+}
+
 export const createBookmark = async (payload: Payload) => {
   const { uid, album } = payload
   const { id, imageUrl, name, artist } = album
@@ -19,4 +24,13 @@ export const createBookmark = async (payload: Payload) => {
     },
     createdAt: timestamp
   })
+}
+
+export const getIsBookmarked = async (data: Query): Promise<boolean> => {
+  const { uid, albumId } = data
+
+  const query = await bookmarksRef(uid)
+    .where('album.id', '==', albumId)
+    .get()
+  return !query.empty
 }

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -11,7 +11,7 @@ type Query = {
   albumId: string
 }
 
-export const createBookmark = async (payload: Payload) => {
+export const createBookmark = async (payload: Payload): Promise<void> => {
   const { uid, album } = payload
   const { id, imageUrl, name, artist } = album
 

--- a/app/repositories/firestore/users/index.ts
+++ b/app/repositories/firestore/users/index.ts
@@ -6,7 +6,15 @@ type Payload = {
   displayName: string
 }
 
-export const createUser = async (payload: Payload) => {
+type UserData = {
+  uid: string
+  displayName: User['displayName']
+  profileText: User['profileText']
+  siteUrl: User['siteUrl']
+  image: User['image']
+}
+
+export const createUser = async (payload: Payload): Promise<void> => {
   const { uid, displayName } = payload
 
   await usersRef.doc(uid).set({
@@ -22,17 +30,18 @@ export const createUser = async (payload: Payload) => {
   })
 }
 
-export const getUser = async ({ uid }: { uid: string }) => {
+export const getUser = async (uid: string): Promise<UserData | undefined> => {
   const doc = await usersRef.doc(uid).get()
   if (!doc.exists) return
 
   const { displayName, profileText, siteUrl, image } = doc.data() as User
-
-  return {
+  const response: UserData = {
     uid,
     displayName,
     profileText,
     siteUrl,
     image
   }
+
+  return response
 }

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -20,7 +20,7 @@ export const mutations: MutationTree<RootState> = {
 
 export const actions: ActionTree<RootState, RootState> = {
   async login({ commit }, { uid }: { uid: string }) {
-    const user = await getUser({ uid })
+    const user = await getUser(uid)
     if (!user) return
 
     commit('setLoginUser', user)

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,9 @@ service cloud.firestore {
       }
 
       match /bookmarks/{bookmarkID} {
+        allow list: if isAuthenticated()
+                    && isUserAuthenticated(userID);
+
         allow create: if isAuthenticated()
                       && isUserAuthenticated(userID)
                       && isBookmarkValid(incomingData());


### PR DESCRIPTION
## 📝 関連 issue
related to #87 

## 🔨 変更内容
albums/_albumId.vue
- 変数名の変更 `isFavorite => isBookmarked`
- mounted() Firestore クエリ getIsBookmarked() の呼び出しおよび data 反映処理追加
  - インラインコメントの追加
- methods bookmark() リファクタおよびインラインコメントの追加

repositories/ bookmarks/
- ブックマーク済みであるかどうかを取得するクエリを追加
- 関数の返り値に対し型宣言を追加

repsitories/ users/
- 関数の返り値に型宣言を追加する等のリファクタ

firestore.rules
- bookmarks コレクションについて list のルール追加

## 👀 確認手順
+ [ ] 個別アルバムページにおいてブックマーク済みの場合、アイコンの表示がそのように対応されていることを確認
