### PR TITLE
追加したブックマークの削除

### DIFF
--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -67,6 +67,7 @@ import { MetaInfo } from 'vue-meta'
 import { Album } from '~/types/spotify-api.d.ts'
 import {
   createBookmark,
+  deleteBookmark,
   getIsBookmarked
 } from '~/repositories/firestore/bookmarks'
 
@@ -140,17 +141,23 @@ export default Vue.extend({
       // switch flag
       this.isBookmarked = !this.isBookmarked
 
-      if (!this.isBookmarked) return
-
       const uid = this.$firebase.currentUser?.uid
+      const albumId = this.albumId
+      const album = this.album as Album
+
       if (!uid) return
 
+      // delete firestore bookmark document
+      if (!this.isBookmarked) {
+        deleteBookmark({ uid, albumId })
+        return
+      }
+
       // create firestore bookmark document
-      const album = this.album as Album
       const data = {
         uid,
         album: {
-          id: this.albumId,
+          id: albumId,
           imageUrl: album.images[1].url,
           name: album.name,
           artist: album.artists[0].name

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -26,11 +26,26 @@ export const createBookmark = async (payload: Payload): Promise<void> => {
   })
 }
 
+export const deleteBookmark = async (data: Query): Promise<void> => {
+  const { uid, albumId } = data
+  // get target document
+  const query = await bookmarksRef(uid)
+    .where('album.id', '==', albumId)
+    .get()
+  if (query.empty) return
+
+  const bookmarkId = query.docs[0].id
+  await bookmarksRef(uid)
+    .doc(bookmarkId)
+    .delete()
+}
+
 export const getIsBookmarked = async (data: Query): Promise<boolean> => {
   const { uid, albumId } = data
 
   const query = await bookmarksRef(uid)
     .where('album.id', '==', albumId)
     .get()
+
   return !query.empty
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,8 +29,8 @@ service cloud.firestore {
       }
 
       match /bookmarks/{bookmarkID} {
-        allow list: if isAuthenticated()
-                    && isUserAuthenticated(userID);
+        allow list, delete: if isAuthenticated()
+                            && isUserAuthenticated(userID);
 
         allow create: if isAuthenticated()
                       && isUserAuthenticated(userID)


### PR DESCRIPTION
## 📝 関連 issue
resolves #87 

## 🔨 変更内容
firestore.rules 
+ bookmarks コレクションに対し、delete ルールを追加

repositories/bookmarks
+ 対象 bookmark データの削除クエリを追加

pages/albums/_albumId
+ 追加したブックマークの削除ロジック（上記クエリの呼び出し）を追加

## 👀 確認手順
+ [ ] ブックマークの削除が行えることを確認
+ [ ] ブックマーク削除のデータ操作を Firestore コンソールから確認
