### PR TITLE
ユーザー個別ページの作成ならびにルーティングおよび AppBar ページタイトルの追加

### DIFF
--- a/app/assets/sprite/svg/person.svg
+++ b/app/assets/sprite/svg/person.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -21,6 +21,7 @@ export type PageTitle =
   | '最新リリース'
   | '利用規約'
   | 'プライバシーポリシー'
+  | 'マイページ'
 
 export default Vue.extend({
   props: {
@@ -48,7 +49,7 @@ export default Vue.extend({
   height: 44px;
   padding: 4px 16px;
   background: $white;
-  border: 1px solid $boundaryBlack;
+  border-bottom: 1px solid $boundaryBlack;
   z-index: 2;
 
   > .title {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
     },
 
     pageTitle(): PageTitle {
-      const { path } = this.$route
+      const { path, params } = this.$route
 
       switch (path) {
         case '/signup/':
@@ -52,6 +52,12 @@ export default Vue.extend({
           return '利用規約'
         case '/policy/':
           return 'プライバシーポリシー'
+        //
+        case `/users/${params.uid}/`: {
+          const uid = this.$firebase.currentUser?.uid
+          const isMyPage = uid === params.uid
+          return isMyPage ? 'マイページ' : ''
+        }
         default:
           return ''
       }

--- a/app/middleware/valid-login.ts
+++ b/app/middleware/valid-login.ts
@@ -1,16 +1,21 @@
 import { Middleware, Context } from '@nuxt/types'
+import { User } from '~/types/firestore'
 
 const validateLgoin: Middleware = ({ store, route, redirect }: Context) => {
-  const loginUser: any = store.state.loginUser
+  const loginUser: User = store.state.loginUser
   const isLoggedIn: boolean = !!loginUser
+  const albumId: string = route.params.albumId
+  const uid: string = route.params.uid
 
   const validPath = (paths: readonly string[]): boolean => {
     const validate = (path: string): boolean => route.path === path
     return !!paths.find((path) => validate(path))
   }
-
-  const albumId: string = route.params.albumId
-  const pathsShouldLoggedIn = ['/releases/', `/albums/${albumId}/`] as const
+  const pathsShouldLoggedIn = [
+    '/releases/',
+    `/albums/${albumId}/`,
+    `/users/${uid}/`
+  ] as const
   const pathsShouldNotLoggedIn = ['/', '/signup/', '/login/'] as const
 
   if (validPath(pathsShouldLoggedIn) && !isLoggedIn) return redirect('/')

--- a/app/pages/releases.vue
+++ b/app/pages/releases.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="container">
+    <nav class="leading">
+      <button class="icon" @click="pushToMyPage()">
+        <svg-icon name="person" title="my-page" />
+      </button>
+    </nav>
     <ListReleases />
   </div>
 </template>
@@ -15,6 +20,15 @@ export default Vue.extend({
     ListReleases
   },
 
+  methods: {
+    pushToMyPage() {
+      const uid = this.$firebase.currentUser?.uid
+      if (!uid) return
+
+      this.$router.push(`/users/${uid}/`)
+    }
+  },
+
   head(): MetaInfo {
     return {
       title: 'リリース'
@@ -26,5 +40,26 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .container {
   margin-top: 56px;
+
+  > .leading {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    top: 0;
+    left: 16px;
+    height: 44px;
+    z-index: 3;
+
+    > .icon {
+      width: 24px;
+      height: 24px;
+
+      > svg {
+        width: 100%;
+        height: 100%;
+        color: $gray;
+      }
+    }
+  }
 }
 </style>

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -1,0 +1,10 @@
+<template>
+  <div />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({})
+</script>
+
+<style lang="scss" scoped></style>

--- a/app/types/firestore.d.ts
+++ b/app/types/firestore.d.ts
@@ -1,4 +1,5 @@
 export type User = {
+  uid: string
   displayName: string
   profileText: null | string
   siteUrl: null | string


### PR DESCRIPTION
## 📝 関連 issue
related to #71 

## 🔨 変更内容
File: `assets/~/svg/person` の追加

componets/TheAppBar:
- 型 PageTitle に 'マイページ' を追加
- スタイルの修正

layouts/default:
- compurted pageTitle() に switch 文に 'マイページ' を返すロジックを追加

middleware/:
- ログイン状態に関するルーティングバリーデーションに /users のルートについて追加

pages/releases:
- /users/_uid/ へ遷移させるボタンの表示およびロジックを追加

## 👀 確認手順
+ [ ] ログイン後、最新リリースページの左上アイコンからユーザー個別ページへアクセスできることを確認
