### PR TITLE
マイページに表示するブックマークリストコンポーネントの作成、リーディングアイコンの変更

### DIFF
--- a/app/components/users/ListBookmarks.vue
+++ b/app/components/users/ListBookmarks.vue
@@ -1,0 +1,76 @@
+<template>
+  <ul class="list-favorites">
+    <li
+      v-for="(bookmark, index) in bookmarks"
+      :key="`bookmark-${index}`"
+      class="bookmark"
+    >
+      <nuxt-link :to="`/albums/${bookmark.album.id}/`">
+        <img
+          class="img"
+          :src="bookmark.album.imageUrl"
+          :alt="`${bookmark.album.name}の画像`"
+        />
+        <p class="title">
+          {{ bookmark.album.name }}
+        </p>
+        <p class="artist">
+          {{ bookmark.album.artist }}
+        </p>
+      </nuxt-link>
+    </li>
+  </ul>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Bookmark } from '~/types/firestore'
+import { getBookmarks } from '~/repositories/firestore/bookmarks'
+
+export default Vue.extend({
+  async fetch() {
+    this.$store.commit('setIsLoading', true)
+
+    const uid = this.$route.params.uid
+    const bookmarks = await getBookmarks(uid)
+
+    this.$store.commit('setIsLoading', false)
+    if (bookmarks) this.bookmarks = bookmarks
+  },
+
+  data() {
+    return {
+      bookmarks: [] as Bookmark[]
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.list-favorites {
+  display: flex;
+  flex-wrap: wrap;
+
+  > .bookmark {
+    margin: 0 0 16px 16px;
+    width: calc(50% - 24px);
+
+    > a {
+      > .img {
+        width: 100%;
+        border: 1px solid $boundaryBlack;
+        border-radius: 8px;
+      }
+
+      > .title {
+        margin-top: -4px;
+      }
+
+      > .artist {
+        line-height: 1;
+        color: $gray;
+      }
+    }
+  }
+}
+</style>

--- a/app/pages/releases.vue
+++ b/app/pages/releases.vue
@@ -2,7 +2,8 @@
   <div class="container">
     <nav class="leading">
       <button class="icon" @click="pushToMyPage()">
-        <svg-icon name="person" title="my-page" />
+        <img v-if="!!userImageUrl" :src="userImageUrl" alt="マイページへ" />
+        <img v-else src="~/assets/images/default-icon.png" alt="マイページへ" />
       </button>
     </nav>
     <ListReleases />
@@ -18,6 +19,13 @@ import ListReleases from '~/components/releases/ListReleases.vue'
 export default Vue.extend({
   components: {
     ListReleases
+  },
+
+  computed: {
+    userImageUrl(): string {
+      const imageUrl: string = this.$store.state.loginUser?.image.url
+      return imageUrl
+    }
   },
 
   methods: {
@@ -44,9 +52,9 @@ export default Vue.extend({
   > .leading {
     display: flex;
     align-items: center;
-    position: absolute;
+    position: fixed;
     top: 0;
-    left: 16px;
+    margin-left: 16px;
     height: 44px;
     z-index: 3;
 
@@ -54,10 +62,12 @@ export default Vue.extend({
       width: 24px;
       height: 24px;
 
-      > svg {
+      > img {
         width: 100%;
         height: 100%;
-        color: $gray;
+        object-fit: cover;
+        border: 1px solid $boundaryBlack;
+        border-radius: 50%;
       }
     }
   }

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -1,17 +1,21 @@
 <template>
   <div v-if="user" class="container">
-    <SectionProfile :user="user" />
+    <SectionProfile :user="user" class="profile" />
+    <ListBookmarks />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import SectionProfile from '~/components/users/SectionProfile.vue'
 import { User } from '~/types/firestore'
+
+import SectionProfile from '~/components/users/SectionProfile.vue'
+import ListBookmarks from '~/components/users/ListBookmarks.vue'
 
 export default Vue.extend({
   components: {
-    SectionProfile
+    SectionProfile,
+    ListBookmarks
   },
 
   computed: {
@@ -25,5 +29,10 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .container {
   margin-top: 56px;
+
+  > .profile {
+    border-bottom: 1px solid $boundaryBlack;
+    margin-bottom: 16px;
+  }
 }
 </style>

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -49,3 +49,18 @@ export const getIsBookmarked = async (data: Query): Promise<boolean> => {
 
   return !query.empty
 }
+
+export const getBookmarks = async (
+  uid: string
+): Promise<Bookmark[] | undefined> => {
+  const query = await bookmarksRef(uid).get()
+
+  if (query.empty) return
+
+  const response = query.docs.map((doc) => {
+    const { album, createdAt } = doc.data() as Bookmark
+    return { album, createdAt }
+  })
+
+  return response
+}

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -53,7 +53,9 @@ export const getIsBookmarked = async (data: Query): Promise<boolean> => {
 export const getBookmarks = async (
   uid: string
 ): Promise<Bookmark[] | undefined> => {
-  const query = await bookmarksRef(uid).get()
+  const query = await bookmarksRef(uid)
+    .orderBy('createdAt', 'desc')
+    .get()
 
   if (query.empty) return
 


### PR DESCRIPTION
## 📝 関連 issue
related to #71 

## 🔨 変更内容
repositories/ bookmarks
- ユーザー毎のブックマークデータを取得するクエリを追加

components/ ListBookmarks
- ブックマークリストコンポーネントの作成

pages/users
- 上記コンポーネントの表示ロジックを追加

pages/releases
- 左上リーディングアイコンを、ユーザーデータのアイコンが設定されている場合、そちらを用いるよう変更（現状更新手段がないが、将来のための対応）

## 👀 確認手順
+ [ ] ブックマークを作成したのち、マイページにて上記コンポーネントの表示を確認

## 留意事項
ListBookmarks コンポーネント fetch 内の this が eslint によってエラーとなるが、
次回のマージにて `nuxt-eslint-plugin` のアップデートを行うことで解決することとする