### PR TITLE
Cloud Functions ソースコードのリファクタならびにレスポンス修正

### DIFF
--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -33,7 +33,7 @@
         トラックリスト
       </h1>
       <ul>
-        <li v-for="track in album.tracks" :key="track.track_number">
+        <li v-for="track in album.tracks.items" :key="track.track_number">
           <p>
             <span class="number">{{ track.track_number }}</span>
             {{ track.name }}
@@ -44,7 +44,7 @@
     <p class="date">
       <time>リリース: {{ releaseDate }}</time>
     </p>
-    <!-- FAB -->
+    <!-- Floating Action Button -->
     <div class="fab-container">
       <div class="fabs">
         <div>

--- a/functions/src/spotify/get-album.ts
+++ b/functions/src/spotify/get-album.ts
@@ -41,40 +41,55 @@ const getAlbum = async (id: string): Promise<SpotifyAlbum> => {
   return response
 }
 
+const processResult = (data: Album): Album => {
+  const {
+    album_type,
+    artists,
+    external_urls,
+    id,
+    images,
+    name,
+    release_date
+  } = data
+
+  const tracks = data.tracks.items.map((track: Track) => {
+    const {
+      artists,
+      external_urls,
+      id,
+      name,
+      preview_url,
+      track_number
+    } = track
+
+    return {
+      artists,
+      external_urls,
+      id,
+      name,
+      preview_url,
+      track_number
+    }
+  })
+
+  return {
+    album_type,
+    artists,
+    external_urls,
+    id,
+    images,
+    name,
+    release_date,
+    tracks: {
+      items: tracks
+    }
+  }
+}
+
 module.exports = functions
   .region('asia-northeast1')
   .https.onCall(async (data: RequestData) => {
     const result = await getAlbum(data.albumId)
-    const {
-      album_type,
-      artists,
-      external_urls,
-      id,
-      images,
-      name,
-      release_date
-    } = result.data
-
-    const tracks = result.data.tracks.items.map((track: Track) => {
-      // process return value
-      return {
-        artists: track.artists,
-        external_urls: track.external_urls,
-        id: track.id,
-        name: track.name,
-        preview_url: track.preview_url,
-        track_number: track.track_number
-      }
-    })
-
-    return {
-      album_type,
-      artists,
-      external_urls,
-      id,
-      images,
-      name,
-      release_date,
-      tracks
-    }
+    const response = processResult(result.data)
+    return response
   })

--- a/functions/src/spotify/get-new-releases.ts
+++ b/functions/src/spotify/get-new-releases.ts
@@ -41,30 +41,35 @@ const getNewReleases = async (offset: number): Promise<Releases> => {
   return response
 }
 
+const processResult = (data: Albums) => {
+  const items = data.albums.items.map((item: Item) => {
+    const {
+      album_type,
+      artists,
+      external_urls,
+      id,
+      images,
+      name,
+      release_date
+    } = item
+
+    return {
+      album_type,
+      artists,
+      external_urls,
+      id,
+      images,
+      name,
+      release_date
+    }
+  })
+  return items
+}
+
 module.exports = functions
   .region('asia-northeast1')
   .https.onCall(async (data: RequestData) => {
     const result = await getNewReleases(data.offset)
-    const items = result.data.albums.items.map((item: Item) => {
-      // process return value
-      const {
-        album_type,
-        artists,
-        external_urls,
-        id,
-        images,
-        name,
-        release_date
-      } = item
-      return {
-        album_type,
-        artists,
-        external_urls,
-        id,
-        images,
-        name,
-        release_date
-      }
-    })
-    return items
+    const response = processResult(result.data)
+    return response
   })


### PR DESCRIPTION
## 🔨 変更内容
functions/src/spotify/
- データをマップする処理を関数として分割し、可読性を改善

/get-album.ts
- Spotify API レスポンスに合わせて、レスポンスのネストを変更 `res.tracks => res.tracks.items`

pages/ _albumId
- 上記レスポンスの変更に対応

## 👀 確認手順
+ [ ] Spotify API から取得するデータ表示が以前と変わりないことを確認
