### PR TITLE
Callable Functions エラーハンドリング追加

### DIFF
--- a/app/components/releases/ListReleases.vue
+++ b/app/components/releases/ListReleases.vue
@@ -85,11 +85,15 @@ export default Vue.extend({
         threshold: 1.0
       }
       const callback = (entries: IntersectionObserverEntry[]) => {
-        entries.forEach((entry) => {
+        for (const entry of entries) {
           if (!entry.isIntersecting) return
-          // pagenation
-          this.fetchReleases({ offset: this.releases.length })
-        })
+          // query pagenation by scroll
+          const offset = this.releases.length
+          // max releases object is 100
+          if (offset < 100) this.fetchReleases({ offset })
+          // if all data has been getted
+          else if (this.observer) this.observer.unobserve(this.observerElement)
+        }
       }
       const observer = new IntersectionObserver(callback, options)
       this.observer = observer

--- a/functions/src/spotify/get-album.ts
+++ b/functions/src/spotify/get-album.ts
@@ -88,8 +88,25 @@ const processResult = (data: Album): Album => {
 
 module.exports = functions
   .region('asia-northeast1')
-  .https.onCall(async (data: RequestData) => {
-    const result = await getAlbum(data.albumId)
+  .https.onCall(async (data: RequestData, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'The function must be called ' + 'while authenticated.'
+      )
+    }
+
+    const { albumId } = data
+
+    if (!albumId) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'albumId is undefined.',
+        { albumId }
+      )
+    }
+
+    const result = await getAlbum(albumId)
     const response = processResult(result.data)
     return response
   })

--- a/functions/src/spotify/get-new-releases.ts
+++ b/functions/src/spotify/get-new-releases.ts
@@ -68,8 +68,25 @@ const processResult = (data: Albums) => {
 
 module.exports = functions
   .region('asia-northeast1')
-  .https.onCall(async (data: RequestData) => {
-    const result = await getNewReleases(data.offset)
+  .https.onCall(async (data: RequestData, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'The function must be called ' + 'while authenticated.'
+      )
+    }
+
+    const { offset } = data
+
+    if (typeof offset !== 'number') {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'offset is must be a number',
+        { offset }
+      )
+    }
+
+    const result = await getNewReleases(offset)
     const response = processResult(result.data)
     return response
   })


### PR DESCRIPTION
## 🔨 変更内容
functions/src/
+ callable functions の引数 data および context.auth について、エラーハンドリングを追加
  + context.auth が存在しなければエラー`failed-precondition` を返す
  + data にクエリに必要なプロパティが存在しなければエラー`invalid-argument` を返す

components/ ListRelease.vue
- observer の callback 関数をリファクタ
  - 配列処理 `forEach` => `for ~ of` に変更
  - リリースオブジェクトが全て取得済みの際に余計なクエリを行わないよう if 文の追加。また、その場合 unobserve の呼び出しを追加

## 👀 確認手順
+ [ ] Functions が正しく呼び出され、Spotify API のデータが正しく表示されることを確認
