### PR TITLE
FileReader を使用した image ファイルの読み込み、firestore.rules の更新

### DIFF
--- a/app/components/form/ImageUploader.vue
+++ b/app/components/form/ImageUploader.vue
@@ -35,7 +35,7 @@ export default Vue.extend({
   },
 
   methods: {
-    onImageSelected(e: HTMLElementEvent<HTMLInputElement>) {
+    onImageSelected(e: HTMLElementEvent<HTMLInputElement>): void {
       const file = e.target.files ? e.target.files[0] : null
       if (!file) return
 
@@ -48,6 +48,7 @@ export default Vue.extend({
         )
         return
       }
+
       // validate file size (max size is 10MB)
       if (file.size > 1024 * 1024 * 10) {
         alert(
@@ -55,6 +56,7 @@ export default Vue.extend({
         )
         return
       }
+
       // display image
       const reader = new FileReader()
       reader.readAsDataURL(file)
@@ -62,6 +64,8 @@ export default Vue.extend({
         if (!target || !target.result) return
         this.image = target.result as string
       }
+
+      this.$emit('onFileUploaded', file)
     }
   }
 })

--- a/app/components/form/ImageUploader.vue
+++ b/app/components/form/ImageUploader.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="image-uploader">
     <svg-icon class="icon" name="actions/upload" alt="画像をアップロード" />
-    <input type="file" accept="image/png,image/jpeg" />
+    <input
+      type="file"
+      accept="image/png,image/jpeg"
+      @change="onImageSelected"
+    />
     <div class="filter" />
     <img :src="imageUrl" alt="ユーザー画像" class="icon" />
   </div>
@@ -10,17 +14,54 @@
 <script lang="ts">
 import Vue from 'vue'
 
+interface HTMLElementEvent<T extends HTMLElement> extends Event {
+  target: T
+}
+
 export default Vue.extend({
   data() {
     return {
-      image: ''
+      image: '' as string
     }
   },
 
   computed: {
     imageUrl(): string {
+      if (this.image) return this.image
+
       const imageUrl = this.$store.state.loginUser?.imageUrl
       return imageUrl ?? require('~/assets/images/default-icon.png')
+    }
+  },
+
+  methods: {
+    onImageSelected(e: HTMLElementEvent<HTMLInputElement>) {
+      const file = e.target.files ? e.target.files[0] : null
+      if (!file) return
+
+      // validate file extension
+      const fileExtension = file.type.split('/')[1]
+      const validExtensions = ['png', 'jpg', 'jpeg']
+      if (!validExtensions.includes(fileExtension)) {
+        alert(
+          'ファイルの形式が正しくありません\npng、jpg または jpeg 拡張子の画像を指定してください'
+        )
+        return
+      }
+      // validate file size (max size is 10MB)
+      if (file.size > 1024 * 1024 * 10) {
+        alert(
+          'ファイルのサイズが大きすぎます\n10MB 以下の画像を指定してください'
+        )
+        return
+      }
+      // display image
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.onload = ({ target }) => {
+        if (!target || !target.result) return
+        this.image = target.result as string
+      }
     }
   }
 })
@@ -32,8 +73,8 @@ export default Vue.extend({
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 72px;
-  height: 72px;
+  width: 96px;
+  height: 96px;
   background: $lightGray;
   border-radius: 50%;
 

--- a/app/components/users/SectionProfile.vue
+++ b/app/components/users/SectionProfile.vue
@@ -45,6 +45,9 @@ export default Vue.extend({
   > .icon {
     width: 72px;
     height: 72px;
+    object-fit: cover;
+    border: 1px solid $boundaryBlack;
+    border-radius: 50%;
   }
 
   > .site {

--- a/app/components/users/SectionProfile.vue
+++ b/app/components/users/SectionProfile.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
 
   computed: {
     imageUrl(): string {
-      const imageUrl = this.$store.state.loginUser?.imageUrl
+      const imageUrl = this.$store.state.loginUser?.image.url
       return imageUrl ?? require('~/assets/images/default-icon.png')
     }
   }

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="user" class="users-page">
     <nav class="leading">
-      <button class="icon" @click="$router.back()">
+      <button class="icon" @click="$router.push('/releases/')">
         <svg-icon name="navigation/arrow_back" title="戻る" />
       </button>
       <button class="icon" @click="$router.push('/settings/')">

--- a/firestore.rules
+++ b/firestore.rules
@@ -34,11 +34,10 @@ service cloud.firestore {
       }
 
       function isUpdateUserValid(data) {
-        return (data.profileText == null || validString(data.profileText, 1, 160))
-        && (data.siteUrl == null
-            || (validUrl(data.siteUrl) && validString(data.siteUrl, 1, 100)))
-        && data.image.id == null
-        && data.image.url == null
+        return data.profileText == null || validString(data.profileText, 1, 160)
+        && data.siteUrl == null || (validUrl(data.siteUrl) && validString(data.siteUrl, 1, 100))
+        && data.image.id == null || validString(data.image.id, 20, 20)
+        && data.image.url == null || validUrl(data.image.url)
         && data.createdAt != data.updatedAt;
       }
 


### PR DESCRIPTION
## 📝 関連 issue
related to #121 

## 🔨 変更内容
components/ ImageUploader
- change イベントでアップロードされた image のバリデートおよび FileReader を使用した画像の表示ロジックを作成

pages/users
- プロフィール画像表示のための `computed.imageUrl` を修正
- leading icon による遷移先を最新リリースに修正

firestore.rules
- users モデルの更新について `image.id` および `image.url` に関するバリデートを追記

## 👀 確認手順
+ [ ]
