### PR TITLE
プロフィール画像更新機能（Cloud Storage へのアップロード）

### DIFF
--- a/app/components/form/ImageUploader.vue
+++ b/app/components/form/ImageUploader.vue
@@ -4,7 +4,7 @@
     <input
       type="file"
       accept="image/png,image/jpeg"
-      @change="onImageSelected"
+      @change="onImageSelected()"
     />
     <div class="filter" />
     <img :src="imageUrl" alt="ユーザー画像" class="icon" />
@@ -29,7 +29,7 @@ export default Vue.extend({
     imageUrl(): string {
       if (this.image) return this.image
 
-      const imageUrl = this.$store.state.loginUser?.imageUrl
+      const imageUrl = this.$store.state.loginUser?.image.url
       return imageUrl ?? require('~/assets/images/default-icon.png')
     }
   },

--- a/app/utils/use-document-id.ts
+++ b/app/utils/use-document-id.ts
@@ -1,0 +1,10 @@
+// https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/util/misc.ts#L25
+export const useDocumentId = () => {
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'
+  let id = ''
+  for (let i = 0; i < 20; i++) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return id
+}

--- a/app/utils/use-upload-image.ts
+++ b/app/utils/use-upload-image.ts
@@ -1,0 +1,27 @@
+import firebase from '../plugins/firebase/init'
+import 'firebase/storage'
+
+type Payload = {
+  path: string
+  file: File
+}
+
+export const useUploadImage = async (payload: Payload): Promise<string> => {
+  const { path, file } = payload
+  const ref: firebase.storage.Reference = firebase
+    .storage()
+    .ref()
+    .child(path)
+
+  // upload image to storage
+  await ref.put(file).catch(() => {
+    throw new Error('アップロードエラー')
+  })
+
+  // download url from storage
+  const url: string = await ref.getDownloadURL().catch(() => {
+    throw new Error('ダウンロードエラー')
+  })
+
+  return url
+}


### PR DESCRIPTION
## 📝 関連 issue
resolves #121 

## 🔨 変更内容
components/ FormProfiles
+ data() の型 `type Profile` を追加

components/ ImageUploader
+ `computed.imageUrl` 修正
+ Cloud Storage に画像をアップロードを行うロジックを追加

utils/ use-upload-image
- CloudStorage に画像をアップロードする関数を作成

utils/ use-document-id
- 画像ファイル名のための ID 生成関数を作成

storage.rules
- 画像ファイルアップロードについて、サイズを含むバリデートを追加

## 👀 確認手順
+ [ ] プロフィール設定より、画像のアップロード後にフォームを送信し、画像が更新されることを確認
