### PR TITLE
storage.rules の更新　サイズおよびコンテンツタイプについて

### DIFF
--- a/app/components/form/ImageUploader.vue
+++ b/app/components/form/ImageUploader.vue
@@ -4,7 +4,7 @@
     <input
       type="file"
       accept="image/png,image/jpeg"
-      @change="onImageSelected()"
+      @change="onImageSelected"
     />
     <div class="filter" />
     <img :src="imageUrl" alt="ユーザー画像" class="icon" />

--- a/storage.rules
+++ b/storage.rules
@@ -1,7 +1,10 @@
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if request.auth!=null;
+      allow read: if request.auth!=null;
+      allow write: if request.auth != null
+                   && request.resource.size < 10 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
     }
   }
 }


### PR DESCRIPTION
## 📝 関連 issue
related to #130 

## 🔨 変更内容
storage.rules
+ write 権限についてルールを追記
  + 画像サイズは `10MB` までとする
  + コンテンツタイプは `image` である必要がある

## 👀 確認手順
+ [ ] プロフィール更新において、画像のアップロードが問題なく行えることを確認
