### PR TITLE
投稿作成ロジックおよびルールの更新

### DIFF
--- a/app/components/albums/FormPost.vue
+++ b/app/components/albums/FormPost.vue
@@ -10,7 +10,7 @@
       <button
         class="submit"
         :disabled="!isCommentValid"
-        @click="$emit('onSubmit')"
+        @click="$emit('onSubmit', comment)"
       >
         シェア
       </button>

--- a/app/components/settings/FormProfiles.vue
+++ b/app/components/settings/FormProfiles.vue
@@ -55,7 +55,7 @@ import BaseButton from '~/components/form/BaseButton.vue'
 import { User } from '~/types/firestore'
 import { RootState } from '~/store'
 
-import { updateUser } from '~/repositories/firestore/users'
+import { updateUser } from '~/repositories/firestore'
 import { useDocumentId } from '~/utils/use-document-id'
 import { useUploadImage } from '~/utils/use-upload-image'
 

--- a/app/components/signup/FormSignUp.vue
+++ b/app/components/signup/FormSignUp.vue
@@ -40,7 +40,7 @@ import Vue from 'vue'
 
 import BaseInputText from '~/components/form/BaseInputText.vue'
 import BaseButton from '~/components/form/BaseButton.vue'
-import { createUser } from '~/repositories/firestore/users'
+import { createUser } from '~/repositories/firestore'
 
 type AuthError = Error & { code: string }
 

--- a/app/components/users/ListBookmarks.vue
+++ b/app/components/users/ListBookmarks.vue
@@ -25,7 +25,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Bookmark } from '~/types/firestore'
-import { getBookmarks } from '~/repositories/firestore/bookmarks'
+import { getBookmarks } from '~/repositories/firestore'
 
 export default Vue.extend({
   async fetch() {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .only-sp-view {
   width: 100%;
-  max-width: 414px;
+  max-width: $maxViewWidth;
   margin: 0 auto;
   background: #fcfcfc;
   display: block;

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -55,7 +55,7 @@
               :class="{ '-active': isBookmarked }"
             />
           </button>
-          <button class="fab create" @click="switchModalVisible(true)">
+          <button class="fab create" @click="switchFormVisible(true)">
             <svg-icon name="actions/create" title="create" />
           </button>
         </div>
@@ -64,7 +64,8 @@
     <!-- full page modal form -->
     <FormPost
       v-show="isFormVisible"
-      @onClickClose="switchModalVisible(false)"
+      @onClickClose="switchFormVisible(false)"
+      @onSubmit="_createPost($event)"
     />
   </article>
 </template>
@@ -81,7 +82,7 @@ import {
   createBookmark,
   deleteBookmark,
   getIsBookmarked
-} from '~/repositories/firestore/bookmarks'
+} from '~/repositories/firestore'
 
 type Response = void | { data: Album }
 
@@ -154,7 +155,7 @@ export default Vue.extend({
   },
 
   methods: {
-    switchModalVisible(bool: boolean): void {
+    switchFormVisible(bool: boolean): void {
       this.isFormVisible = bool
     },
 
@@ -185,6 +186,10 @@ export default Vue.extend({
         }
       }
       createBookmark(data)
+    },
+
+    async _createPost(comment: string): Promise<void> {
+      await console.log(comment)
     }
   },
 

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -1,7 +1,7 @@
 import { bookmarksRef, timestamp } from '~/repositories/firestore/config'
 import { Bookmark } from '~/types/firestore'
 
-type Payload = {
+export type Payload = {
   uid: string
   album: Bookmark['album']
 }

--- a/app/repositories/firestore/bookmarks/index.ts
+++ b/app/repositories/firestore/bookmarks/index.ts
@@ -1,4 +1,4 @@
-import { bookmarksRef, timestamp } from '~/repositories/firestore/config.ts'
+import { bookmarksRef, timestamp } from '~/repositories/firestore/config'
 import { Bookmark } from '~/types/firestore'
 
 type Payload = {

--- a/app/repositories/firestore/index.ts
+++ b/app/repositories/firestore/index.ts
@@ -1,0 +1,3 @@
+export * from '~/repositories/firestore/posts'
+export * from '~/repositories/firestore/bookmarks'
+export * from '~/repositories/firestore/users'

--- a/app/repositories/firestore/users/index.ts
+++ b/app/repositories/firestore/users/index.ts
@@ -1,4 +1,4 @@
-import { usersRef, timestamp } from '~/repositories/firestore/config.ts'
+import { usersRef, timestamp } from '~/repositories/firestore/config'
 import { User } from '~/types/firestore'
 
 type Payload = {

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,5 +1,5 @@
 import { ActionTree, MutationTree } from 'vuex'
-import { getUser } from '~/repositories/firestore/users'
+import { getUser } from '~/repositories/firestore'
 import { User } from '~/types/firestore'
 
 export const state = () => ({

--- a/firestore.rules
+++ b/firestore.rules
@@ -61,6 +61,29 @@ service cloud.firestore {
           && data.createdAt is timestamp;
         }
       }
+
+      match /posts/{postID} {
+        allow list: if isAuthenticated()
+                    && isUserAuthenticated(userID);
+
+        allow create: if isAuthenticated()
+                      && isUserAuthenticated(userID)
+                      && isPostValid(incomingData());
+
+        function isPostValid(data) {
+          return data.size() == 4
+          && data.keys().hasAll(['album', 'comment', 'createdAt', 'updatedAt'])
+          && data.album is map
+          && data.album.keys().hasAll(['id', 'imageUrl', 'artist', 'name'])
+          && validUrl(data.album.imageUrl)
+          && validString(data.album.id, 0, 30)
+          && validString(data.album.artist, 0, 200)
+          && validString(data.album.name, 0, 200)
+          && validString(data.comment, 1, 800)
+          && data.createdAt is timestamp
+          && data.updatedAt is timestamp;
+        }
+      }
     }
 
     function isAuthenticated() {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -79,7 +79,11 @@ const config: Configuration = {
   /*
    ** Customize the progress-bar color
    */
-  loading: { color: '#fff' },
+  loading: {
+    color: '#007c91', // primary color
+    height: '4px',
+    continuous: true
+  },
   /*
    ** Global CSS
    */


### PR DESCRIPTION
## 📝 関連 issue
related to #127 

## 🔨 変更内容
nuxt.config.ts
- ビルトインローディングのプロパティ `color`, `height`, `continuous` を変更

firestore.rules
- 投稿モデル作成についてルールを追加

repositories/ index.ts
- Re-export を行うファイルを追加
  - 各関数 import の記述を上記ファイルより import するよう変更

pages/ _albumId.vue
- computed `uid`, `queryPayload` を追加
- methods `_createPost` について投稿作成のロジックを追加

## 👀 確認手順
+ [ ] アルバム個別ページのより、投稿を作成し、Firestore コンソールよりデータの作成を確認
