### PR TITLE
投稿の取得および表示

### DIFF
--- a/app/components/albums/FormPost.vue
+++ b/app/components/albums/FormPost.vue
@@ -10,7 +10,7 @@
       <button
         class="submit"
         :disabled="!isCommentValid"
-        @click="$emit('onSubmit', comment)"
+        @click="$emit('onSubmit', { comment })"
       >
         シェア
       </button>

--- a/app/components/users/ListPosts.vue
+++ b/app/components/users/ListPosts.vue
@@ -1,6 +1,30 @@
 <template>
-  <ul>
-    <li>posts</li>
+  <ul class="list-posts">
+    <li v-for="(post, index) in posts" :key="`post-${index}`" class="post">
+      <nuxt-link :to="`/albums/${post.album.id}/`" class="card">
+        <div class="header">
+          <time>{{ formatDate(post.createdAt.toDate()) }}</time>
+        </div>
+        <div class="contents">
+          <div>
+            <p class="title">
+              {{ post.album.name }}
+            </p>
+            <p class="artist">
+              {{ post.album.artist }}
+            </p>
+            <p class="comment">
+              {{ post.comment }}
+            </p>
+          </div>
+          <img
+            class="img"
+            :src="post.album.imageUrl"
+            :alt="`${post.album.name}の画像`"
+          />
+        </div>
+      </nuxt-link>
+    </li>
   </ul>
 </template>
 
@@ -21,8 +45,82 @@ export default Vue.extend({
     return {
       posts: [] as PostData[]
     }
+  },
+
+  methods: {
+    formatDate(createdAt: string): string {
+      return this.$dayjs(createdAt).fromNow()
+    }
   }
 })
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.list-posts {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 16px;
+
+  > .post {
+    width: calc(100% + 32px);
+    height: 200px;
+    margin: 0 -16px;
+    border-bottom: 1px solid $boundaryBlack;
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  color: $black;
+
+  > .header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 16px;
+
+    > time {
+      @include caption;
+      color: $gray;
+    }
+  }
+
+  .contents {
+    display: flex;
+    justify-content: space-between;
+
+    .comment {
+      max-height: 80px;
+      margin-right: 16px;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 4;
+      overflow: hidden;
+    }
+
+    .title {
+      @include subhead;
+      line-height: 1;
+      margin: -4px 0 8px;
+    }
+
+    .artist {
+      @include caption;
+      color: $gray;
+      line-height: 1;
+      margin-bottom: 12px;
+    }
+
+    > .img {
+      width: 96px;
+      min-width: 96px;
+      height: 96px;
+      border: 1px solid $boundaryBlack;
+      border-radius: 8px;
+    }
+  }
+}
+</style>

--- a/app/components/users/ListPosts.vue
+++ b/app/components/users/ListPosts.vue
@@ -1,0 +1,28 @@
+<template>
+  <ul>
+    <li>posts</li>
+  </ul>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { getUserPosts, PostData } from '~/repositories/firestore'
+
+export default Vue.extend({
+  async fetch() {
+    const uid = this.$firebase.currentUser?.uid
+    if (!uid) return
+
+    const posts = await getUserPosts({ uid })
+    if (posts) this.posts = posts
+  },
+
+  data() {
+    return {
+      posts: [] as PostData[]
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -202,7 +202,7 @@ export default Vue.extend({
       }
     },
 
-    async _createPost(comment: string): Promise<void> {
+    async _createPost({ comment }: { comment: string }): Promise<void> {
       if (!this.queryPayload) return
 
       const data = {

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -10,6 +10,7 @@
     </nav>
     <SectionProfile :user="user" class="profile" />
     <ListBookmarks />
+    <ListPosts />
   </div>
 </template>
 
@@ -20,11 +21,13 @@ import { RootState } from '~/store'
 
 import SectionProfile from '~/components/users/SectionProfile.vue'
 import ListBookmarks from '~/components/users/ListBookmarks.vue'
+import ListPosts from '~/components/users/ListPosts.vue'
 
 export default Vue.extend({
   components: {
     SectionProfile,
-    ListBookmarks
+    ListBookmarks,
+    ListPosts
   },
 
   computed: {

--- a/app/repositories/firestore/posts/index.ts
+++ b/app/repositories/firestore/posts/index.ts
@@ -1,4 +1,5 @@
 import { postsRef, timestamp } from '~/repositories/firestore/config'
+import { getUser, UserData } from '~/repositories/firestore'
 import { Post } from '~/types/firestore'
 
 type Payload = {
@@ -7,18 +8,20 @@ type Payload = {
   comment: Post['comment']
 }
 
-type PostData = {
+type PostField = {
   album: Post['album']
   comment: Post['comment']
   createdAt: typeof timestamp
   updatedAt: typeof timestamp
 }
 
+export type PostData = Post & { user: UserData }
+
 export const createPost = async (payload: Payload): Promise<void> => {
   const { uid, album, comment } = payload
   const { id, imageUrl, name, artist } = album
 
-  const data: PostData = {
+  const data: PostField = {
     album: {
       id,
       imageUrl,
@@ -31,4 +34,49 @@ export const createPost = async (payload: Payload): Promise<void> => {
   }
 
   await postsRef(uid).add(data)
+}
+
+export const getUserPosts = async ({ uid }: { uid: string }) => {
+  const query = await postsRef(uid)
+    .orderBy('createdAt', 'desc')
+    .get()
+  if (query.empty) return []
+
+  const mapping = query.docs.map(async (doc) => {
+    const { album, comment, createdAt, updatedAt } = doc.data() as Post
+    const { id, imageUrl, name, artist } = album
+
+    // get author data
+    const uid = doc.ref.path.split('/')[1]
+    const user = await getUser(uid)
+    if (!user) return
+
+    const { displayName, profileText, siteUrl, image } = user
+    const postData: PostData = {
+      album: {
+        id,
+        imageUrl,
+        name,
+        artist
+      },
+      comment,
+      createdAt,
+      updatedAt,
+      user: {
+        uid,
+        displayName,
+        profileText,
+        siteUrl,
+        image
+      }
+    }
+    return postData
+  })
+
+  // filter
+  const posts = (await (await Promise.all(mapping)).filter(
+    (post) => post !== undefined
+  )) as PostData[]
+
+  return posts
 }

--- a/app/repositories/firestore/users/index.ts
+++ b/app/repositories/firestore/users/index.ts
@@ -6,7 +6,7 @@ type Payload = {
   displayName: string
 }
 
-type UserData = {
+export type UserData = {
   uid: string
   displayName: User['displayName']
   profileText: User['profileText']


### PR DESCRIPTION
## 📝 関連 issue
related to #127

## 🔨 変更内容
`ListPosts` コンポーネントの作成
- Firestore クエリの呼び出し
- 表示ロジックおよびスタイリング

pages/ _uid
- 上記コンポーネントの表示ロジック

repositories/ posts
- ユーザーの投稿一覧取得クエリを作成

## 👀 確認手順
+ [ ] ユーザーページにて投稿の表示を確認
