### PR TITLE
ユーザーページにコンテンツ切り替えのためのタブバーを追加

### DIFF
--- a/app/assets/sprite/svg/message.svg
+++ b/app/assets/sprite/svg/message.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/app/components/users/ListBookmarks.vue
+++ b/app/components/users/ListBookmarks.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="list-favorites">
+  <ul class="list-bookmarks">
     <li
       v-for="(bookmark, index) in bookmarks"
       :key="`bookmark-${index}`"
@@ -47,7 +47,7 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.list-favorites {
+.list-bookmarks {
   display: flex;
   flex-wrap: wrap;
 

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -26,6 +26,7 @@
       </button>
       <span class="underline" :class="`-active-${activeTab}`" />
     </p>
+
     <ListBookmarks v-show="activeTab === 1" />
     <ListPosts v-show="activeTab === 2" />
   </div>
@@ -111,7 +112,7 @@ export default Vue.extend({
   &::after {
     content: '';
     position: absolute;
-    bottom: -4px;
+    bottom: -2px;
     width: 100%;
     height: 1px;
     background: $boundaryBlack;
@@ -120,7 +121,7 @@ export default Vue.extend({
   > .underline {
     position: absolute;
     left: 0;
-    bottom: -4px;
+    bottom: -2px;
     width: 50%;
     height: 2px;
     background: $primary;
@@ -133,12 +134,12 @@ export default Vue.extend({
   }
 
   > .icon {
-    width: 24px;
-    height: 24px;
+    position: relative;
+    width: 50%;
 
     > svg {
-      width: 100%;
-      height: 100%;
+      width: 24px;
+      height: 24px;
       color: $lightGray;
 
       &.-active {

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -9,8 +9,25 @@
       </button>
     </nav>
     <SectionProfile :user="user" class="profile" />
-    <ListBookmarks />
-    <ListPosts />
+    <p class="tabs">
+      <button class="icon" @click="switchActiveTab(1)">
+        <svg-icon
+          name="message"
+          title="投稿"
+          :class="{ '-active': activeTab === 1 }"
+        />
+      </button>
+      <button class="icon" @click="switchActiveTab(2)">
+        <svg-icon
+          name="actions/bookmark"
+          title="favorite"
+          :class="{ '-active': activeTab === 2 }"
+        />
+      </button>
+      <span class="underline" :class="`-active-${activeTab}`" />
+    </p>
+    <ListBookmarks v-show="activeTab === 1" />
+    <ListPosts v-show="activeTab === 2" />
   </div>
 </template>
 
@@ -30,9 +47,21 @@ export default Vue.extend({
     ListPosts
   },
 
+  data() {
+    return {
+      activeTab: 1 as number
+    }
+  },
+
   computed: {
     user(): User | null {
       return (this.$store.state as RootState).loginUser
+    }
+  },
+
+  methods: {
+    switchActiveTab(tabNumber: number): void {
+      this.activeTab = tabNumber
     }
   }
 })
@@ -41,8 +70,11 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .users-page {
   > .profile {
-    border-bottom: 1px solid $boundaryBlack;
-    margin-bottom: 16px;
+    margin-bottom: 8px;
+  }
+
+  > .list-bookmarks {
+    margin-top: 16px;
   }
 
   > .leading {
@@ -65,6 +97,52 @@ export default Vue.extend({
         color: $gray;
         width: 100%;
         height: 100%;
+      }
+    }
+  }
+}
+
+.tabs {
+  position: relative;
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -4px;
+    width: 100%;
+    height: 1px;
+    background: $boundaryBlack;
+  }
+
+  > .underline {
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 50%;
+    height: 2px;
+    background: $primary;
+    transition: all 0.3s ease-in-out;
+    z-index: 2;
+
+    &.-active-2 {
+      left: 50%;
+    }
+  }
+
+  > .icon {
+    width: 24px;
+    height: 24px;
+
+    > svg {
+      width: 100%;
+      height: 100%;
+      color: $lightGray;
+
+      &.-active {
+        color: $primary;
       }
     }
   }

--- a/app/repositories/firestore/posts/index.ts
+++ b/app/repositories/firestore/posts/index.ts
@@ -39,6 +39,7 @@ export const createPost = async (payload: Payload): Promise<void> => {
 export const getUserPosts = async ({ uid }: { uid: string }) => {
   const query = await postsRef(uid)
     .orderBy('createdAt', 'desc')
+    .limit(10)
     .get()
   if (query.empty) return []
 


### PR DESCRIPTION
## 📝 関連 issue
related to #122 

## 🔨 変更内容
SVG `message.svg` の追加

pages/ _uid
- コンテンツ切り替えのための UI タブバーを追加

repositories/ 
- クエリ `getUserPosts` に limit を設定

## 👀 確認手順
+ [ ] ユーザーページにてタブバーによる表示コンテンツ切り替えを確認
