### PR TITLE
UI のスタイルリングに関するリファクタおよび img:alt 属性 svg:title 属性の更新

### DIFF
--- a/app/assets/styles/_variables.scss
+++ b/app/assets/styles/_variables.scss
@@ -31,6 +31,7 @@ $boundaryBlack: rgba(46, 56, 54, 0.13);
 //
 // Shadows
 //
+$shadowVery: rgba(46, 56, 54, 0.2) 0px 3px 4px -3px, rgba(46, 56, 54, 0.14) 0px 4px 8px 0px, rgba(46, 56, 54, 0.12) 0px 1px 11px 0px;
 $shadowHigh: rgba(46, 56, 54, 0.2) 0px 3px 3px -2px, rgba(46, 56, 54, 0.14) 0px 3px 4px 0px, rgba(46, 56, 54, 0.12) 0px 1px 8px 0px;
 $shadowMiddle: rgba(46, 56, 54, 0.2) 0px 3px 1px -2px,rgba(46, 56, 54, 0.14) 0px 2px 2px 0px, rgba(46, 56, 54, 0.12) 0px 1px 5px 0px;
 $shadowLow: rgba(46, 56, 54, 0.2) 0px 2px 1px -1px, rgba(46, 56, 54, 0.14) 0px 1px 1px 0px, rgba(46, 56, 54, 0.12) 0px 1px 3px 0px;

--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -2,7 +2,7 @@
   <section class="app-bar">
     <nav v-if="backIconVisible" class="nav leading">
       <button class="icon" @click="$router.back()">
-        <svg-icon name="navigation/arrow_back" title="back" />
+        <svg-icon name="navigation/arrow_back" title="戻る" />
       </button>
     </nav>
     <h1 class="title">

--- a/app/components/TheAppBar.vue
+++ b/app/components/TheAppBar.vue
@@ -64,8 +64,8 @@ export default Vue.extend({
     position: absolute;
 
     > .icon {
-      width: 24px;
-      height: 24px;
+      width: 28px;
+      height: 28px;
 
       svg {
         width: 100%;

--- a/app/components/albums/FormPost.vue
+++ b/app/components/albums/FormPost.vue
@@ -82,8 +82,8 @@ export default Vue.extend({
   }
 
   > .cancel {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
 
     > svg {
       width: 100%;

--- a/app/components/form/BaseButton.vue
+++ b/app/components/form/BaseButton.vue
@@ -36,9 +36,31 @@ export default Vue.extend({
   border-radius: 4px;
   background: $primary;
   color: $white;
+  position: relative;
+  transition-duration: 0.25s;
 
   &:disabled {
     opacity: 0.5;
+  }
+
+  &:hover {
+    opacity: 0.95;
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 32px;
+    width: 100%;
+    box-shadow: $shadowVery;
+    opacity: 0;
+    transition-duration: 0.1s;
   }
 }
 </style>

--- a/app/components/form/ImageUploader.vue
+++ b/app/components/form/ImageUploader.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="image-uploader">
-    <svg-icon class="icon" name="actions/upload" alt="画像をアップロード" />
+    <svg-icon class="icon" name="actions/upload" title="画像をアップロード" />
     <input
       type="file"
       accept="image/png,image/jpeg"

--- a/app/components/users/SectionProfile.vue
+++ b/app/components/users/SectionProfile.vue
@@ -8,7 +8,7 @@
       {{ user.profileText }}
     </p>
     <div v-if="user.siteUrl" class="site">
-      <svg-icon name="link" title="site" />
+      <svg-icon name="link" title="ウェブサイト" />
       <a :href="user.siteUrl" target="_blank" rel="noopener noreferrer">
         {{ user.siteUrl }}
       </a>

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="error-layout">
     <div class="error">
-      <svg-icon name="alert/error_outline" title="alert" />
+      <svg-icon name="alert/error_outline" title="エラー" />
       <p class="msg">
         {{ message }}
       </p>

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -48,10 +48,10 @@
     <div class="fab-container">
       <div class="fabs">
         <div>
-          <button class="fab favorite" @click="bookmark()">
+          <button class="fab bookmark" @click="bookmark()">
             <svg-icon
               :name="`actions/${bookmarkIcon}`"
-              title="favorite"
+              title="bookmark"
               :class="{ '-active': isBookmarked }"
             />
           </button>
@@ -308,6 +308,24 @@ export default Vue.extend({
       height: 56px;
       border-radius: 50%;
       box-shadow: $shadowHigh;
+      position: relative;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        background: rgba($black, 0);
+        transition-duration: 0.1s;
+      }
+
+      &:hover::after {
+        background: rgba($black, 0.05);
+        box-shadow: $shadowVery;
+      }
 
       > svg {
         width: 24px;
@@ -323,7 +341,7 @@ export default Vue.extend({
         color: $white;
       }
 
-      &.favorite {
+      &.bookmark {
         background: $white;
         color: $gray;
         margin-bottom: 16px;

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -51,12 +51,12 @@
           <button class="fab bookmark" @click="bookmark()">
             <svg-icon
               :name="`actions/${bookmarkIcon}`"
-              title="bookmark"
+              title="ブックマークする"
               :class="{ '-active': isBookmarked }"
             />
           </button>
           <button class="fab create" @click="switchFormVisible(true)">
-            <svg-icon name="actions/create" title="create" />
+            <svg-icon name="actions/create" title="投稿する" />
           </button>
         </div>
       </div>

--- a/app/pages/albums/_albumId.vue
+++ b/app/pages/albums/_albumId.vue
@@ -144,6 +144,8 @@ export default Vue.extend({
   },
 
   async mounted(): Promise<void> {
+    this.$store.commit('setIsLoading', true)
+
     const albumId = this.albumId
     const uid = this.uid
 
@@ -159,17 +161,15 @@ export default Vue.extend({
     ](albumId)
     if (storeAlbum) {
       this.album = storeAlbum
-      return
+      return this.$store.commit('setIsLoading', false)
     }
 
     // fetch from Spotify API
-    this.$store.commit('setIsLoading', true)
-
     const api = this.$functions.httpsCallable('spotifyGetAlbum')
     const response: Response = await api({ albumId }).catch((error: Error) =>
       this.$nuxt.error(error)
     )
-    if (!response) return
+    if (!response) return this.$store.commit('setIsLoading', false)
 
     const album = response.data
     this.album = album

--- a/app/pages/releases.vue
+++ b/app/pages/releases.vue
@@ -55,8 +55,8 @@ export default Vue.extend({
     z-index: 3;
 
     > .icon {
-      width: 24px;
-      height: 24px;
+      width: 28px;
+      height: 28px;
 
       > img {
         width: 100%;

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -13,14 +13,14 @@
       <button class="icon" @click="switchActiveTab(1)">
         <svg-icon
           name="message"
-          title="投稿"
+          title="投稿一覧"
           :class="{ '-active': activeTab === 1 }"
         />
       </button>
       <button class="icon" @click="switchActiveTab(2)">
         <svg-icon
           name="actions/bookmark"
-          title="favorite"
+          title="ブックマーク一覧"
           :class="{ '-active': activeTab === 2 }"
         />
       </button>

--- a/app/pages/users/_uid/index.vue
+++ b/app/pages/users/_uid/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="user" class="users-page">
     <nav class="leading">
-      <button class="icon" @click="$router.push('/releases/')">
+      <button class="icon back" @click="$router.push('/releases/')">
         <svg-icon name="navigation/arrow_back" title="戻る" />
       </button>
       <button class="icon" @click="$router.push('/settings/')">
@@ -26,9 +26,8 @@
       </button>
       <span class="underline" :class="`-active-${activeTab}`" />
     </p>
-
-    <ListBookmarks v-show="activeTab === 1" />
-    <ListPosts v-show="activeTab === 2" />
+    <ListPosts v-show="activeTab === 1" />
+    <ListBookmarks v-show="activeTab === 2" />
   </div>
 </template>
 
@@ -93,6 +92,11 @@ export default Vue.extend({
     > .icon {
       width: 24px;
       height: 24px;
+
+      &.back {
+        width: 28px;
+        height: 28px;
+      }
 
       > svg {
         color: $gray;


### PR DESCRIPTION
## 🔨 変更内容
- `_varibales.scss` / 変数 `$shadowVery` を追加
- 各 leading アイコンのサイズを変更 24px => 28px
- BaseButton コンポーネントならびに FAB に hover 時のスタイルを追加
- アルバム個別ページにおけるローディング開始タイミングを修正
- ユーザーページにおけるコンポーネントの表示について、タブの対応を修正
- img タグ alt 属性 および svg タグ title 属性をよりセマンティクスな内容に変更

## 👀 確認手順
+ [ ] 上記項目について、アプリの見た目を確認
