### PR TITLE
Update validate router path with complement trailing slash

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -43,8 +43,11 @@ export default Vue.extend({
 
     pageTitle(): PageTitle {
       const { path, params } = this.$route
+      // Complement trailing slash
+      const pathWithTrailingSlash = (path: string): string =>
+        path.slice(-1) === '/' ? path : `${path}/`
 
-      switch (path) {
+      switch (pathWithTrailingSlash(path)) {
         case '/signup/':
           return 'ユーザー登録'
         case '/login/':

--- a/app/middleware/valid-login.ts
+++ b/app/middleware/valid-login.ts
@@ -8,16 +8,17 @@ const validateLgoin: Middleware = ({ store, route, redirect }: Context) => {
   const uid: string = route.params.uid
 
   const validPath = (paths: readonly string[]): boolean => {
-    const validate = (path: string): boolean => route.path === path
+    const validate = (path: string): boolean =>
+      route.path === path || route.path === `${path}/`
     return !!paths.find((path) => validate(path))
   }
   const pathsShouldLoggedIn = [
-    '/releases/',
-    `/albums/${albumId}/`,
-    `/users/${uid}/`,
-    `/settings/`
+    '/releases',
+    `/albums/${albumId}`,
+    `/users/${uid}`,
+    `/settings`
   ] as const
-  const pathsShouldNotLoggedIn = ['/', '/signup/', '/login/'] as const
+  const pathsShouldNotLoggedIn = ['', '/signup', '/login'] as const
 
   if (validPath(pathsShouldLoggedIn) && !isLoggedIn) return redirect('/')
   if (validPath(pathsShouldNotLoggedIn) && isLoggedIn) {


### PR DESCRIPTION
## 📝 関連 issue
resolves #139 

## 🔨 変更内容
middleware/valid-login.ts, layouts/default.vue
- ビルトイン route プロパティに対するバリデート関数において、path の末尾にスラッシュがない場合、それを補完する処理を追加

## 👀 確認手順
+ [ ] 末尾にスラッシュが存在しない URL にアクセスしても、ログイン状態に応じたリダイレクトがされること、ならびに正しくデータが表示されることを確認
