### PR TITLE
ローディング時にボタン disabled 付与、ならびに onSnapShot リスナーのタイムアウト追加

### DIFF
--- a/app/components/form/BaseButton.vue
+++ b/app/components/form/BaseButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     class="base-button"
-    :disabled="disabled"
+    :disabled="buttonDisabled"
     @click.prevent="$emit('onClick')"
   >
     {{ label }}
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { RootState } from '~/store'
 
 export default Vue.extend({
   props: {
@@ -20,6 +21,12 @@ export default Vue.extend({
     disabled: {
       type: Boolean,
       required: true
+    }
+  },
+
+  computed: {
+    buttonDisabled(): boolean {
+      return this.disabled || (this.$store.state as RootState).isLoading
     }
   }
 })

--- a/app/components/settings/FormProfiles.vue
+++ b/app/components/settings/FormProfiles.vue
@@ -173,6 +173,20 @@ export default Vue.extend({
 
         const unsubscribe = ref.onSnapshot(
           (snapshot: firebase.firestore.DocumentSnapshot) => {
+            let resolved = false
+            const resolveListener = () => {
+              this.$store.commit('setIsLoading', false)
+              this.$router.push(`/users/${uid}/`)
+              resolve()
+              unsubscribe()
+              resolved = true
+            }
+
+            // handle timeout
+            setTimeout(() => {
+              if (!resolved) resolveListener()
+            }, 3000)
+
             const updatedAt = snapshot.get('updatedAt').toMillis() / 1000
             if (now.seconds > updatedAt) return // if update not completed
 
@@ -191,10 +205,7 @@ export default Vue.extend({
               image
             }
             this.$store.commit('setLoginUser', newProfile) // update store state
-            this.$store.commit('setIsLoading', false)
-            this.$router.push(`/users/${uid}/`)
-            resolve()
-            unsubscribe()
+            resolveListener()
           }
         )
       })


### PR DESCRIPTION
## 🔨 変更内容
タイトルの通り

## 👀 確認手順
+ [ ] ローディング時にボタン（BaseButton コンポーネント）イベントが使用できないことを確認
+ [ ] プロフィール更新時に、更新フィールドが存在しない場合などにタイムアウトによる処理が行われることを確認
